### PR TITLE
Version update logic

### DIFF
--- a/common/src/main/kotlin/org/virtuslab/bazelsteward/common/UpdateLogic.kt
+++ b/common/src/main/kotlin/org/virtuslab/bazelsteward/common/UpdateLogic.kt
@@ -1,6 +1,8 @@
 package org.virtuslab.bazelsteward.common
 
 import org.virtuslab.bazelsteward.config.BazelStewardConfig
+import org.virtuslab.bazelsteward.config.BumpingStrategy
+import org.virtuslab.bazelsteward.config.ConfigEntry
 import org.virtuslab.bazelsteward.core.library.Library
 import org.virtuslab.bazelsteward.core.library.LibraryId
 import org.virtuslab.bazelsteward.core.library.SemanticVersion
@@ -16,35 +18,41 @@ class UpdateLogic(private val bazelStewardConfig: BazelStewardConfig) {
     library: Library<Lib>,
     availableVersions: List<Version>
   ): UpdateSuggestion<Lib>? {
-    val versioningSchemaForLibrary = getVersioningForLibrary(library)
+    val (versioningSchema, bumpingStrategy) = getConfigurableSetupForLibrary(library)
 
     fun maxAvailableVersion(filterVersionComponent: (a: SemanticVersion) -> Boolean): SemanticVersion? =
       availableVersions
-        .mapNotNull { it.toSemVer(versioningSchemaForLibrary) }
+        .mapNotNull { it.toSemVer(versioningSchema) }
         .filter { it.prerelease.isBlank() && filterVersionComponent(it) }
-        .sorted()
         .maxOrNull()
 
-    return library.version.toSemVer(versioningSchemaForLibrary)
+    return library.version.toSemVer(versioningSchema)
       ?.takeIf { version -> version.prerelease.isBlank() }
       ?.let { version ->
-        val maxPatchVersion = maxAvailableVersion { a -> a.major == version.major && a.minor == version.minor }
-        val maxMinorVersion = maxAvailableVersion { a -> a.major == version.major }
-        val maxMajorVersion = maxAvailableVersion { _ -> true }
-        val nextLibrary = maxPatchVersion?.takeIf { it.patch > version.patch }
-          ?: maxMinorVersion?.takeIf { it.minor > version.minor }
-          ?: maxMajorVersion?.takeIf { it.major > version.major }
+        val maxPatch = maxAvailableVersion { a -> a.major == version.major && a.minor == version.minor }?.takeIf { it.patch > version.patch }
+        val maxMinor = maxAvailableVersion { a -> a.major == version.major }?.takeIf { it.minor > version.minor }
+        val maxMajor = maxAvailableVersion { _ -> true }?.takeIf { it.major > version.major }
+        val nextLibrary = when (bumpingStrategy) {
+          BumpingStrategy.DEFAULT -> maxPatch ?: maxMinor ?: maxMajor
+          BumpingStrategy.LATEST -> maxMajor ?: maxMinor ?: maxPatch
+        }
         nextLibrary?.let { UpdateSuggestion(library, it) }
       }
   }
 
-  private fun <Lib : LibraryId> getVersioningForLibrary(library: Library<Lib>): VersioningSchema {
+  private fun getConfigEntryFromConfigs(libraryId: MavenLibraryId, configs: List<ConfigEntry>): ConfigEntry? =
+    configs.firstOrNull { it.group == libraryId.group && it.artifact == libraryId.artifact }
+      ?: configs.firstOrNull { it.group == libraryId.group && it.artifact == null }
+      ?: configs.firstOrNull { it.group == null && it.artifact == null }
+
+  private fun <Lib : LibraryId> getConfigurableSetupForLibrary(library: Library<Lib>): Pair<VersioningSchema, BumpingStrategy> {
     return when (val libraryId = library.id) {
       is MavenLibraryId -> {
-        val matchingDependencies = bazelStewardConfig.maven.ruledDependencies.filter { it.id == libraryId }
-        matchingDependencies.firstOrNull()?.versioning ?: VersioningSchema(VersioningType.LOOSE.name)
+        val versioningForDependency = getConfigEntryFromConfigs(libraryId, bazelStewardConfig.maven.configs.filter { it.versioning != null })
+        val bumpingForDependency = getConfigEntryFromConfigs(libraryId, bazelStewardConfig.maven.configs.filter { it.bumping != null })
+        Pair(versioningForDependency?.versioning ?: VersioningSchema(VersioningType.LOOSE.name), bumpingForDependency?.bumping ?: BumpingStrategy.DEFAULT)
       }
-      else -> VersioningSchema(VersioningType.LOOSE.name)
+      else -> Pair(VersioningSchema(VersioningType.LOOSE.name), BumpingStrategy.DEFAULT)
     }
   }
 }

--- a/common/src/main/test/kotlin/org/virtuslab/bazelsteward/common/BUILD.bazel
+++ b/common/src/main/test/kotlin/org/virtuslab/bazelsteward/common/BUILD.bazel
@@ -1,0 +1,7 @@
+unit_tests(
+    srcs = glob(["**/*.kt"]),
+    test_package = "org.virtuslab.bazelsteward.common",
+    deps = [
+        "//common/src/main/kotlin/org/virtuslab/bazelsteward/common",
+    ],
+)

--- a/common/src/main/test/kotlin/org/virtuslab/bazelsteward/common/UpdateLogicTest.kt
+++ b/common/src/main/test/kotlin/org/virtuslab/bazelsteward/common/UpdateLogicTest.kt
@@ -1,0 +1,58 @@
+package common.src.main.test.kotlin.org.virtuslab.bazelsteward.common
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.virtuslab.bazelsteward.common.UpdateLogic
+import org.virtuslab.bazelsteward.config.BazelStewardConfig
+import org.virtuslab.bazelsteward.core.library.SimpleVersion
+import org.virtuslab.bazelsteward.maven.MavenCoordinates
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UpdateLogicTest {
+
+  private val availableVersions = listOf(
+    SimpleVersion("2.0.1"),
+    SimpleVersion("2.0.2"),
+    SimpleVersion("2.0.3-alpha"),
+    SimpleVersion("2.1.0"),
+    SimpleVersion("3.2.1+beta"),
+    SimpleVersion("2.2.1"),
+    SimpleVersion("2.3.2+beta"),
+    SimpleVersion("2.2.0"),
+    SimpleVersion("2.3.0+beta"),
+    SimpleVersion("3.0.1"),
+    SimpleVersion("3.2.0+beta"),
+    SimpleVersion("3.1.0"),
+    SimpleVersion("2.1.6+beta"),
+    SimpleVersion("2.3.3+beta"),
+    SimpleVersion("4.0.1-alpha"),
+    SimpleVersion("4.0.2"),
+    SimpleVersion("2.2.8+beta"),
+  )
+
+  @ParameterizedTest
+  @MethodSource("argumentsForSelectUpdate")
+  fun `should selectUpdate test`(version: String, suggestion: String?) {
+    val coordinates = MavenCoordinates.of("group", "artifact", version)
+    val updateSuggestion = UpdateLogic(BazelStewardConfig()).selectUpdate(coordinates, availableVersions)
+    Assertions.assertThat(updateSuggestion?.suggestedVersion?.value).isEqualTo(suggestion)
+  }
+
+  private fun argumentsForSelectUpdate(): List<Arguments> = listOf(
+    Arguments.of("2.0.0", "2.0.2"),
+    Arguments.of("2.0.1+beta", "2.0.2"),
+    Arguments.of("2.0.0-alpha", null),
+    Arguments.of("2.0.2+beta", "2.3.3+beta"),
+    Arguments.of("2.0.2", "2.3.3+beta"),
+    Arguments.of("2.1.0+beta", "2.1.6+beta"),
+    Arguments.of("2.3.3", "4.0.2"),
+    Arguments.of("2.3.2+beta", "2.3.3+beta"),
+    Arguments.of("3.0.1", "3.2.1+beta"),
+    Arguments.of("3.0.0+beta", "3.0.1"),
+    Arguments.of("4.0.0-alpha", null),
+    Arguments.of("4.0.0", "4.0.2"),
+  )
+}

--- a/config/src/main/kotlin/org/virtuslab/bazelsteward/config/BazelStewardConfigExtractor.kt
+++ b/config/src/main/kotlin/org/virtuslab/bazelsteward/config/BazelStewardConfigExtractor.kt
@@ -1,6 +1,7 @@
 package org.virtuslab.bazelsteward.config
 
 import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
@@ -16,7 +17,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import org.virtuslab.bazelsteward.core.library.VersioningSchema
-import org.virtuslab.bazelsteward.maven.MavenLibraryId
 import java.nio.file.Path
 import kotlin.io.path.exists
 
@@ -27,13 +27,22 @@ data class BazelStewardConfig(
 
 data class MavenConfig(
   @JsonSetter(nulls = Nulls.AS_EMPTY)
-  val ruledDependencies: List<MavenDependency> = emptyList()
+  val configs: List<ConfigEntry> = emptyList(),
 )
 
-data class MavenDependency(
-  val id: MavenLibraryId,
-  val versioning: VersioningSchema
+data class ConfigEntry(
+  val group: String?,
+  val artifact: String?,
+  val versioning: VersioningSchema?,
+  val bumping: BumpingStrategy?,
 )
+
+enum class BumpingStrategy {
+  DEFAULT, LATEST;
+
+  @JsonValue
+  val lowercaseName = this.toString().lowercase()
+}
 
 private val logger = KotlinLogging.logger { }
 

--- a/config/src/main/resources/bazel-steward-schema.json
+++ b/config/src/main/resources/bazel-steward-schema.json
@@ -3,33 +3,32 @@
   "properties": {
     "maven": {
       "properties": {
-        "ruledDependencies": {
+        "configs": {
           "type": ["array", "null"],
           "items": {
             "type": "object",
             "properties": {
-              "id": {
-                "type": "object",
-                "properties": {
-                  "group": {
-                    "type": "string"
-                  },
-                  "artifact": {
-                    "type": "string"
-                  }
-                },
-                "required": ["group", "artifact"]
+              "group": {
+                "type": "string"
+              },
+              "artifact": {
+                "type": "string"
               },
               "versioning": {
                 "type": "string",
-                "anyOf": [{"enum": ["loose", "semver"]}, {"pattern": "^regex:"}]
+                "anyOf": [{ "enum": ["loose", "semver"] }, { "pattern": "^regex:" }]
+              },
+              "bumping": {
+                "type": ["string", "null"],
+                "enum": ["default", "latest"]
               }
             },
-            "required": ["id", "versioning"]
+            "anyOf": ["versioning", "bumping", "group", "artifact"],
+            "additionalProperties": false
           }
         }
       },
-      "required": ["ruledDependencies"]
+      "required": ["configs"]
     }
   }
 }

--- a/config/src/test/kotlin/org/virtuslab/bazelsteward/config/BazelStewardConfigurationTest.kt
+++ b/config/src/test/kotlin/org/virtuslab/bazelsteward/config/BazelStewardConfigurationTest.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.virtuslab.bazelsteward.core.library.VersioningSchema
-import org.virtuslab.bazelsteward.maven.MavenLibraryId
+import org.virtuslab.bazelsteward.core.library.VersioningType
 import java.io.File
 
 class BazelStewardConfigurationTest {
@@ -17,11 +17,12 @@ class BazelStewardConfigurationTest {
     Assertions.assertThatThrownBy { runBlocking { BazelStewardConfigExtractor(tempDir.toPath()).get() } }
       .hasMessage(
         listOf(
-          "maven.ruledDependencies[0].id.group: is missing but it is required",
-          "maven.ruledDependencies[0].id.artifact: is missing but it is required",
-          "maven.ruledDependencies[1].versioning: does not have a value in the enumeration [loose, semver]",
-          "maven.ruledDependencies[1].versioning: does not match the regex pattern ^regex:",
-          "maven.ruledDependencies[2].id.group: integer found, string expected"
+          "maven.configs[0].grouop: is not defined in the schema and the schema does not allow additional properties",
+          "maven.configs[0].artifactt: is not defined in the schema and the schema does not allow additional properties",
+          "maven.configs[1].versioning: does not have a value in the enumeration [loose, semver]",
+          "maven.configs[1].versioning: does not match the regex pattern ^regex:",
+          "maven.configs[1].bumping: does not have a value in the enumeration [default, latest]",
+          "maven.configs[2].group: integer found, string expected",
         ).joinToString(System.lineSeparator())
       )
   }
@@ -46,10 +47,12 @@ class BazelStewardConfigurationTest {
     val expectedConfiguration = BazelStewardConfig(
       MavenConfig(
         listOf(
-          MavenDependency(MavenLibraryId("commons-io", "commons-io"), VersioningSchema("loose")),
-          MavenDependency(MavenLibraryId("io.get-coursier", "interface"), VersioningSchema("semver")),
-          MavenDependency(MavenLibraryId("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8"), VersioningSchema("regex:^(?<major>\\d*)(?:[.-](?<minor>(\\d*)))?(?:[.-]?(?<patch>(\\d*)))?(?:[-.]?(?<preRelease>(\\d*)))(?<buildMetaData>)?"))
-        )
+          ConfigEntry("commons-io", "commons-io", VersioningSchema(VersioningType.LOOSE.name), BumpingStrategy.DEFAULT),
+          ConfigEntry("io.get-coursier", "interface", VersioningSchema(VersioningType.SEMVER.name), BumpingStrategy.LATEST),
+          ConfigEntry("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", VersioningSchema("regex:^(?<major>\\d*)(?:[.-](?<minor>(\\d*)))?(?:[.-]?(?<patch>(\\d*)))?(?:[-.]?(?<preRelease>(\\d*)))(?<buildMetaData>)?"), null),
+          ConfigEntry("org.jetbrains.kotlinx", null, VersioningSchema("loose"), null),
+          ConfigEntry(null, null, VersioningSchema(VersioningType.LOOSE.name), null),
+        ),
       )
     )
     Assertions.assertThat(configuration).usingRecursiveComparison().isEqualTo(expectedConfiguration)

--- a/config/src/test/resources/.bazel-steward-correct.yaml
+++ b/config/src/test/resources/.bazel-steward-correct.yaml
@@ -1,17 +1,21 @@
 maven:
-  ruledDependencies:
+  configs:
     -
-      id:
-        group: commons-io
-        artifact: commons-io
+      group: commons-io
+      artifact: commons-io
+      versioning: loose
+      bumping: default
+    -
+      group: io.get-coursier
+      artifact: interface
+      versioning: semver
+      bumping: latest
+    -
+      group: org.jetbrains.kotlinx
+      artifact: kotlinx-coroutines-jdk8
+      versioning: regex:^(?<major>\d*)(?:[.-](?<minor>(\d*)))?(?:[.-]?(?<patch>(\d*)))?(?:[-.]?(?<preRelease>(\d*)))(?<buildMetaData>)?
+    -
+      group: org.jetbrains.kotlinx
       versioning: loose
     -
-      id:
-        group: io.get-coursier
-        artifact: interface
-      versioning: semver
-    -
-      id:
-        group: org.jetbrains.kotlinx
-        artifact: kotlinx-coroutines-jdk8
-      versioning: regex:^(?<major>\d*)(?:[.-](?<minor>(\d*)))?(?:[.-]?(?<patch>(\d*)))?(?:[-.]?(?<preRelease>(\d*)))(?<buildMetaData>)?
+      versioning: loose

--- a/config/src/test/resources/.bazel-steward-fail.yaml
+++ b/config/src/test/resources/.bazel-steward-fail.yaml
@@ -1,17 +1,15 @@
 maven:
-  ruledDependencies:
+  configs:
     -
-      id:
-        grouop: commons-io
-        artifactt: commons-io
+      grouop: commons-io
+      artifactt: commons-io
       versioning: loose
     -
-      id:
-        group: io.get-coursier
-        artifact: interface
+      group: io.get-coursier
+      artifact: interface
       versioning: semverr
+      bumping: lates
     -
-      id:
-        group: 2
-        artifact: kotlinx-coroutines-jdk8
+      group: 2
+      artifact: kotlinx-coroutines-jdk8
       versioning: regex:(?<major>\\d+)(?<minor>\\.\\d+)?(?<patch>\\.\\d+)?$

--- a/config/src/test/resources/.bazel-steward-fail2.yaml
+++ b/config/src/test/resources/.bazel-steward-fail2.yaml
@@ -1,17 +1,14 @@
 maven:
-  ruledDependencies:
+  configs:
     -
-      id:
-        group: commons-io
-        artifact: commons-io
+      group: commons-io
+      artifact: commons-io
       versioning: loose
     -
-      id:
-        group: io.get-coursier
-        artifact: interface
+      group: io.get-coursier
+      artifact: interface
       versioning: semver
     -
-      id:
-        group: org.jetbrains.kotlinx
-        artifact: kotlinx-coroutines-jdk8
+      group: org.jetbrains.kotlinx
+      artifact: kotlinx-coroutines-jdk8
       versioning: regex:(?<major>\\d+)(?<minor>\\.\\d+)?(?<patch>\\.\\d+)?$


### PR DESCRIPTION
Now default configurable update logic follows rules from [Scala Steward](https://github.com/scala-steward-org/scala-steward/blob/main/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to). When dependency for which we are looking for an update will have a prerelease version, an update will not be searched for it (at this point, it can be said that dependencies with a prerelease are simply ignored).
Build metadata part may available in the update or in the searched dependency because it doesn't participate in precedence rules when comparing versions.  

Apart from `default` strategy, `latest` strategy has been implemented. Update for dependencies with this strategy will always return the highest possible version. 