### PR TITLE
Fix loose semver parsing to recognize Kotlin rules

### DIFF
--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/library/SemanticVersion.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/library/SemanticVersion.kt
@@ -79,7 +79,7 @@ data class SemanticVersion(
     private val strictSemVerRegex =
       Regex("""^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<preRelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildMetaData>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?${'$'}""")
     private val looseSemVerRegex =
-      Regex("""^(?<major>0|[1-9]\d*)(?:[.-](?<minor>(0|[1-9]\d*)))?(?:[.-]?(?<patch>(0|[1-9]\d*)))?(?:[-.]?(?<preRelease>((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)))?(?:\+(?<buildMetaData>([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?${'$'}""")
+      Regex("""^[vV]?\.?(?<major>0|[1-9]\d*)(?:[.-](?<minor>(0|[1-9]\d*)))?(?:[.-]?(?<patch>(0|[1-9]\d*)))?(?:[-.]?(?<preRelease>((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)))?(?:\+(?<buildMetaData>([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?${'$'}""")
 
     fun fromString(value: String, versioningScheme: VersioningSchema = VersioningSchema.SemVer): SemanticVersion? {
       fun matchToSemanticVersion(regex: Regex): SemanticVersion? {

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/BazelUpdateTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/BazelUpdateTest.kt
@@ -14,7 +14,7 @@ class BazelUpdateTest : E2EBase() {
     val expectedBranches = expectedBranches(
       "io.arrow-kt/arrow-core" to "1.1.5",
       "io.arrow-kt/arrow-fx-coroutines" to "1.1.5",
-      "rules_jvm_external" to "4.5"
+      "rules_jvm_external" to "4.5",
     )
     checkBranchesWithVersions(tempDir, project, expectedBranches)
   }
@@ -27,7 +27,7 @@ class BazelUpdateTest : E2EBase() {
       "io.arrow-kt/arrow-core" to "1.1.5",
       "io.arrow-kt/arrow-fx-coroutines" to "1.1.5",
       "bazel" to "5.4.0",
-      "rules_jvm_external" to "4.5"
+      "rules_jvm_external" to "4.5",
     )
     checkBranchesWithVersions(tempDir, project, expectedBranches)
   }

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/MavenE2ETest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/MavenE2ETest.kt
@@ -19,7 +19,8 @@ class MavenE2ETest : E2EBase() {
       "io.arrow-kt/arrow-core" to "1.1.5",
       "io.arrow-kt/arrow-fx-coroutines" to "1.1.5",
       "bazel" to "5.4.0",
-      "rules_jvm_external" to "4.5"
+      "rules_jvm_external" to "4.5",
+      "rules_kotlin" to "v1.7.1",
     )
     checkBranchesWithVersions(tempDir, project, expectedBranches)
   }
@@ -28,7 +29,7 @@ class MavenE2ETest : E2EBase() {
   fun `Check dependency update not in maven central repository`(@TempDir tempDir: Path) {
     val project = "maven/external"
     runBazelSteward(tempDir, project)
-    val expectedBranches = expectedBranchPrefixes("com.7theta/utilis", "bazel", "rules_jvm_external")
+    val expectedBranches = expectedBranchPrefixes("com.7theta/utilis", "bazel", "rules_jvm_external", "rules_kotlin")
     checkBranchesWithoutVersions(tempDir, project, expectedBranches)
   }
 

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/RulesUpdateTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/RulesUpdateTest.kt
@@ -15,7 +15,8 @@ class RulesUpdateTest : E2EBase() {
         "io.arrow-kt/arrow-core" to "1.1.5",
         "io.arrow-kt/arrow-fx-coroutines" to "1.1.5",
         "bazel" to "5.4.0",
-        "rules_jvm_external" to "4.5"
+        "rules_jvm_external" to "4.5",
+        "rules_kotlin" to "v1.7.1",
       )
 
     checkBranchesWithVersions(tempDir, project, expectedBranches)


### PR DESCRIPTION
Fixes #66 for Kotlin. Should work for Scala rules > v5.0.0 as long as they maintain somewhat sane versioning schema