### PR TITLE
Add flag to force updating all open PRs

### DIFF
--- a/.github/workflows/dependencies-force.yml
+++ b/.github/workflows/dependencies-force.yml
@@ -1,0 +1,13 @@
+name: Dependencies
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest
+        with:
+          github-personal-token: ${{ secrets.PAT_GITHUB_TOKEN }}
+          additional-args: "--update-all-prs"

--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/App.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/App.kt
@@ -3,18 +3,14 @@ package org.virtuslab.bazelsteward.app
 import mu.KotlinLogging
 import org.virtuslab.bazelsteward.config.repo.RepoConfig
 import org.virtuslab.bazelsteward.core.DependencyKind
-import org.virtuslab.bazelsteward.core.FileFinder
-import org.virtuslab.bazelsteward.core.GitHostClient
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.CLOSED
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.MERGED
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.NONE
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_MERGEABLE
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_MODIFIED
-import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_NOT_MERGEABLE
-import org.virtuslab.bazelsteward.core.PullRequest
 import org.virtuslab.bazelsteward.core.common.GitOperations
 import org.virtuslab.bazelsteward.core.common.UpdateLogic
+import org.virtuslab.bazelsteward.core.common.UpdateSuggestion
+import org.virtuslab.bazelsteward.core.library.Library
+import org.virtuslab.bazelsteward.core.library.Version
+import org.virtuslab.bazelsteward.core.replacement.LibraryUpdate
 import org.virtuslab.bazelsteward.core.replacement.LibraryUpdateResolver
+import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {}
 
@@ -22,75 +18,63 @@ data class App(
   val gitOperations: GitOperations,
   val dependencyKinds: List<DependencyKind<*>>,
   val updateLogic: UpdateLogic,
-  val fileFinder: FileFinder,
   val libraryUpdateResolver: LibraryUpdateResolver,
   val pullRequestSuggester: PullRequestSuggester,
-  val gitHostClient: GitHostClient,
-  val appConfig: AppConfig,
   val repoConfig: RepoConfig,
   val updateRulesProvider: UpdateRulesProvider,
   val libraryToTextFilesMapper: LibraryToTextFilesMapper,
+  val pullRequestManager: PullRequestManager,
+  val workspaceRoot: Path,
 ) {
 
   suspend fun run() {
-    val workspaceRoot = appConfig.workspaceRoot
+    val workspaceRoot = workspaceRoot
     gitOperations.checkoutBaseBranch()
 
     val updates = dependencyKinds.mapNotNull { kind ->
-      val currentLibraries = try {
-        kind.findAvailableVersions(workspaceRoot)
-      } catch (e: Exception) {
-        logger.warn {
-          "Error happened during detecting available versions for ${kind.name}. " +
-            "Skipping this dependency kind..."
-        }
-        logger.warn("Error details: ${e.message}")
-        return@mapNotNull null
-      }
-
-      val updateSuggestions = currentLibraries.mapNotNull {
-        val updateRules = updateRulesProvider.resolveForLibrary(it.key)
-        updateLogic.selectUpdate(it.key, it.value, updateRules)
-      }
-      logger.debug { "UpdateSuggestions: " + updateSuggestions.map { it.currentLibrary.id.name + " to " + it.suggestedVersion.value } }
-
-      val heuristics = kind.defaultVersionReplacementHeuristics // TODO: read from config
-
-      val updates = updateSuggestions.mapNotNull { updateSuggestion ->
-        val libraryFiles = libraryToTextFilesMapper.map(updateSuggestion.currentLibrary)
-        libraryUpdateResolver.resolve(libraryFiles, updateSuggestion, heuristics)
-      }
-
-      updates
+      val currentLibraries = resolveAvailableVersionsOfUsedLibraries(kind, workspaceRoot) ?: return@mapNotNull null
+      val updateSuggestions = resolveUpdateSuggestions(currentLibraries)
+      resolveUpdates(kind, updateSuggestions)
     }.flatten()
 
     val pullRequestSuggestions = pullRequestSuggester.suggestPullRequests(updates)
+    pullRequestManager.applySuggestions(pullRequestSuggestions)
+  }
 
-    pullRequestSuggestions.forEach { pr ->
-      when (val prStatus = gitHostClient.checkPrStatus(pr.branch)) {
-        NONE, OPEN_NOT_MERGEABLE -> {
-          logger.info { "Creating branch ${pr.branch}, PR status: $prStatus" }
-          runCatching {
-            gitOperations.createBranchWithChange(pr.branch, pr.commits)
-            if (appConfig.pushToRemote) {
-              gitOperations.pushBranchToOrigin(pr.branch, force = prStatus == OPEN_NOT_MERGEABLE)
-              val openPr = if (prStatus == NONE) {
-                val oldPrs = gitHostClient.getOpenPrs().filter {
-                  it.branch.name.startsWith(pr.branchPrefix) && it.branch != pr.branch
-                }.filter { gitHostClient.checkPrStatus(it.branch) != OPEN_MODIFIED }
-                gitHostClient.closePrs(oldPrs)
-                gitHostClient.openNewPr(pr.description)
-              } else {
-                PullRequest(pr.branch)
-              }
-              gitHostClient.onPrChange(openPr, prStatus)
-            }
-          }.onFailure { logger.error(it) { "Failed to create branch ${pr.branch}" } }
-          gitOperations.checkoutBaseBranch()
-        }
-
-        CLOSED, MERGED, OPEN_MERGEABLE, OPEN_MODIFIED -> logger.info { "Skipping ${pr.branch}, PR status: $prStatus" }
+  private suspend fun resolveAvailableVersionsOfUsedLibraries(
+    kind: DependencyKind<*>,
+    workspaceRoot: Path
+  ): Map<out Library, List<Version>>? {
+    return try {
+      kind.findAvailableVersions(workspaceRoot)
+    } catch (e: Exception) {
+      logger.warn {
+        "Error happened during detecting available versions for ${kind.name}. " +
+          "Skipping this dependency kind..."
       }
+      logger.warn("Error details: ${e.message}")
+      null
     }
+  }
+
+  private fun resolveUpdateSuggestions(currentLibraries: Map<out Library, List<Version>>): List<UpdateSuggestion> {
+    val updateSuggestions = currentLibraries.mapNotNull {
+      val updateRules = updateRulesProvider.resolveForLibrary(it.key)
+      updateLogic.selectUpdate(it.key, it.value, updateRules)
+    }
+    logger.debug { "UpdateSuggestions: " + updateSuggestions.map { it.currentLibrary.id.name + " to " + it.suggestedVersion.value } }
+    return updateSuggestions
+  }
+
+  private fun resolveUpdates(
+    kind: DependencyKind<*>,
+    updateSuggestions: List<UpdateSuggestion>
+  ): List<LibraryUpdate> {
+    val heuristics = kind.defaultVersionReplacementHeuristics // TODO: read from config
+    val updates = updateSuggestions.mapNotNull { updateSuggestion ->
+      val libraryFiles = libraryToTextFilesMapper.map(updateSuggestion.currentLibrary)
+      libraryUpdateResolver.resolve(libraryFiles, updateSuggestion, heuristics)
+    }
+    return updates
   }
 }

--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppBuilder.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppBuilder.kt
@@ -40,6 +40,12 @@ object AppBuilder {
       fullName = "push-to-remote",
       shortName = "p"
     ).default(true)
+    val updateAllPullRequests by parser.option(
+      ArgType.Boolean,
+      description = "Update all pull requests",
+      fullName = "update-all-prs",
+      shortName = "f"
+    ).default(false)
     val baseBranch by parser.option(
       ArgType.String,
       fullName = "base-branch",
@@ -61,7 +67,14 @@ object AppBuilder {
     val gitAuthor = runBlocking { gitClient.getAuthor() }
     val configResolvedPath = configPath?.let { Path(it) } ?: repositoryRoot.resolve(".bazel-steward.yaml")
 
-    val appConfig = AppConfig(repositoryRoot, configResolvedPath, pushToRemote, baseBranchName, gitAuthor)
+    val appConfig = AppConfig(
+      repositoryRoot,
+      configResolvedPath,
+      pushToRemote,
+      updateAllPullRequests,
+      baseBranchName,
+      gitAuthor
+    )
     logger.info { appConfig }
 
     val repoConfig = runBlocking { RepoConfigParser().load(appConfig.configPath) }
@@ -71,6 +84,12 @@ object AppBuilder {
     val gitOperations = GitOperations(appConfig.workspaceRoot, appConfig.baseBranch)
     val gitHostClient =
       if (github) GithubClient.getClient(env, appConfig.baseBranch, appConfig.gitAuthor) else GitHostClient.stub
+    val pullRequestManager = PullRequestManager(
+      gitHostClient,
+      gitOperations,
+      appConfig.pushToRemote,
+      appConfig.updateAllPullRequests
+    )
     val bazelRulesExtractor = BazelRulesExtractor(appConfig.workspaceRoot)
     val bazelUpdater = BazelUpdater()
     val githubRulesResolver = GithubRulesResolver(
@@ -101,14 +120,13 @@ object AppBuilder {
       gitOperations,
       dependencyKinds,
       updateLogic,
-      fileFinder,
       libraryUpdateResolver,
       pullRequestSuggester,
-      gitHostClient,
-      appConfig,
       repoConfig,
       updateRulesProvider,
-      libraryToTextFilesMapper
+      libraryToTextFilesMapper,
+      pullRequestManager,
+      appConfig.workspaceRoot
     )
   }
 }

--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppConfig.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppConfig.kt
@@ -7,6 +7,7 @@ data class AppConfig(
   val workspaceRoot: Path,
   val configPath: Path,
   val pushToRemote: Boolean,
+  val updateAllPullRequests: Boolean,
   val baseBranch: String,
   val gitAuthor: GitAuthor
 )

--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/PullRequestManager.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/PullRequestManager.kt
@@ -1,0 +1,47 @@
+package org.virtuslab.bazelsteward.app
+
+import mu.KotlinLogging
+import org.virtuslab.bazelsteward.core.GitHostClient
+import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.NONE
+import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_MERGEABLE
+import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_MODIFIED
+import org.virtuslab.bazelsteward.core.GitHostClient.PrStatus.OPEN_NOT_MERGEABLE
+import org.virtuslab.bazelsteward.core.PullRequest
+import org.virtuslab.bazelsteward.core.common.GitOperations
+
+private val logger = KotlinLogging.logger {}
+
+class PullRequestManager(
+  private val gitHostClient: GitHostClient,
+  private val gitOperations: GitOperations,
+  private val pushToRemote: Boolean,
+  private val updateAllPullRequests: Boolean
+) {
+  suspend fun applySuggestions(pullRequestSuggestions: List<PullRequestSuggestion>) {
+    pullRequestSuggestions.forEach { pr ->
+      val prStatus = gitHostClient.checkPrStatus(pr.branch)
+      if (prStatus == NONE || prStatus == OPEN_NOT_MERGEABLE || (updateAllPullRequests && prStatus == OPEN_MERGEABLE)) {
+        logger.info { "Creating branch ${pr.branch}, PR status: $prStatus" }
+        runCatching {
+          gitOperations.createBranchWithChange(pr.branch, pr.commits)
+          if (pushToRemote) {
+            gitOperations.pushBranchToOrigin(pr.branch, force = prStatus != NONE)
+            val openPr = if (prStatus == NONE) {
+              val oldPrs = gitHostClient.getOpenPrs().filter {
+                it.branch.name.startsWith(pr.branchPrefix) && it.branch != pr.branch
+              }.filter { gitHostClient.checkPrStatus(it.branch) != OPEN_MODIFIED }
+              gitHostClient.closePrs(oldPrs)
+              gitHostClient.openNewPr(pr.description)
+            } else {
+              PullRequest(pr.branch)
+            }
+            gitHostClient.onPrChange(openPr, prStatus)
+          }
+        }.onFailure { logger.error(it) { "Failed to create branch ${pr.branch}" } }
+        gitOperations.checkoutBaseBranch()
+      } else {
+        logger.info { "Skipping ${pr.branch}, PR status: $prStatus" }
+      }
+    }
+  }
+}

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/fixture/E2EBase.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/fixture/E2EBase.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions
 import org.virtuslab.bazelsteward.app.App
 import org.virtuslab.bazelsteward.app.AppBuilder
 import org.virtuslab.bazelsteward.app.BazelStewardGitBranch
+import org.virtuslab.bazelsteward.app.PullRequestManager
 import org.virtuslab.bazelsteward.bazel.rules.BazelRulesDependencyKind
 import org.virtuslab.bazelsteward.bazel.version.BazelVersionDependencyKind
 import org.virtuslab.bazelsteward.core.Environment
@@ -135,7 +136,7 @@ open class E2EBase {
     return this.copy(
       dependencyKinds = listOf(
         MavenDependencyKind(
-          MavenDataExtractor(this.appConfig.workspaceRoot),
+          MavenDataExtractor(this.workspaceRoot),
           mockMavenRepositoryWithVersion(*versions.toTypedArray())
         )
       )
@@ -156,7 +157,12 @@ open class E2EBase {
 
   protected fun App.withGitHostClient(gitHostClient: GitHostClient): App {
     return this.copy(
-      gitHostClient = gitHostClient
+      pullRequestManager = PullRequestManager(
+        gitHostClient,
+        this.gitOperations,
+        pushToRemote = true,
+        updateAllPullRequests = false
+      )
     )
   }
 


### PR DESCRIPTION
This PR adds a flag --update-all-prs that will force push and close+open any open PR (so including these, that are up to date and have no conflicts). 
I also added a job in this repo that can be triggered manually, which has this parameter. 
It is helpful for cases like when bazel steward was not able to reopen PRs correctly and now it can, so we should update all these PRs without jobs that we have.