### PR TITLE
Added maxMajor to minor BumpingStrategy

### DIFF
--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
@@ -39,7 +39,7 @@ class UpdateLogic {
         val nextVersion = when (updateRules.bumpingStrategy) {
           BumpingStrategy.Default -> maxPatch ?: maxMinor ?: maxMajor
           BumpingStrategy.Latest -> maxMajor ?: maxMinor ?: maxPatch
-          BumpingStrategy.Minor -> maxMinor ?: maxPatch
+          BumpingStrategy.Minor -> maxMinor ?: maxPatch ?: maxMajor
         }
         nextVersion?.let { UpdateSuggestion(library, it) }
       }


### PR DESCRIPTION
#189. The bug is caused because Default Bumping strategy is Minor which doesn't take max Major in Versions and it is what affects updating Bazel version with different major. So the solution is either Adding maxMajor to minor BumpingStrategy, which I did in this PR, changing default Bumoing Strategy or add exception for the Bazel version