### PR TITLE
Reduced false positives in rules update heuristic

### DIFF
--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/GitOperations.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/GitOperations.kt
@@ -40,7 +40,7 @@ class GitOperations(workspaceRoot: Path, private val baseBranch: String) {
     commits.forEach { commit ->
       commit.changes.groupBy { it.file }.forEach { (path, changes) ->
         val contents = path.readText()
-        val newContents = changes.fold(Pair(contents, 0)) { (content, offset), replacement ->
+        val newContents = changes.sortedBy { it.offset }.fold(Pair(contents, 0)) { (content, offset), replacement ->
           content.replaceRange(
             replacement.offset + offset,
             replacement.offset + offset + replacement.length,

--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/TextFile.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/TextFile.kt
@@ -10,6 +10,10 @@ interface TextFile {
   private class LazyTextFile(override val path: Path) : TextFile {
     override val content: String
       get() = path.readText()
+
+    override fun toString(): String {
+      return path.toString()
+    }
   }
 
   companion object {

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/PostUpdateHookTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/PostUpdateHookTest.kt
@@ -27,7 +27,7 @@ class PostUpdateHookTest : E2EBase() {
         localRoot,
         "sh",
         "-c",
-        """cat garbage/* rubbish/* trash/* | python -c "import sys; print(sum(int(l) for l in sys.stdin))"""",
+        """cat garbage/* rubbish/* trash/* | python3 -c "import sys; print(sum(int(l) for l in sys.stdin))"""",
       ).trim()
       validationCommandOutput shouldBe "45"
       val lastCommit = git.run("log", "-1", "--oneline")
@@ -56,7 +56,7 @@ class PostUpdateHookTest : E2EBase() {
         localRoot,
         "sh",
         "-c",
-        """cat garbage/* rubbish/* trash/* | python -c "import sys; print(sum(int(l) for l in sys.stdin))"""",
+        """cat garbage/* rubbish/* trash/* | python3 -c "import sys; print(sum(int(l) for l in sys.stdin))"""",
       ).trim()
       validationCommandOutput shouldBe "45"
       val lastCommit = git.run("log", "-1", "--oneline")

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules/JvmExternalRulesUpdateTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules/JvmExternalRulesUpdateTest.kt
@@ -4,5 +4,5 @@ import org.virtuslab.bazelsteward.e2e.rules.fixture.RulesUpdate
 
 class JvmExternalRulesUpdateTest : RulesUpdate(
   "rules/rules_jvm_external",
-  "rules_jvm_external" to "5.1",
+  "rules_jvm_external" to "5.2",
 )

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules/heuristic/HeuristicUpdateMultipleUrlsVariablesTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules/heuristic/HeuristicUpdateMultipleUrlsVariablesTest.kt
@@ -3,9 +3,9 @@ package org.virtuslab.bazelsteward.e2e.rules.heuristic
 import org.virtuslab.bazelsteward.e2e.rules.fixture.BazelRulesHeuristicUpdate
 
 class HeuristicUpdateMultipleUrlsVariablesTest : BazelRulesHeuristicUpdate(
-  "rules/heuristic/heuristic_rules_multiple_urls_variables",
-  "https://github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
-  "7d206c2383811f378a5ef03f4aacbcf5f47fd8650f6abbc3fa89f3a27ddcccc",
-  "0.12.0",
-  "rules_closure",
+  project = "rules/heuristic/heuristic_rules_multiple_urls_variables",
+  expectedUrl = "https://github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
+  expectedSha256 = "7d206c2383811f378a5ef03f4aacbcf5f47fd8650f6abbc3fa89f3a27ddcccc",
+  expectedVersion = "0.12.0",
+  expectedBranch = "rules_closure",
 )


### PR DESCRIPTION
Lookup for version and checksum replacement now ignores matches that are surrounded with characters that would definitely be a part of if. This avoids replacements like 
expeced: "3.1" -> "5.2" 
actual: "3.18.2a" -> "5.28.2a"

Additionally, replacements that found more than 2 components of rule version (version + sha + maybe link) are preferred over single replacement which are likely incorrect.

Fixed a bug in FileChange application logic: it must happen in order of offsets of changes. Otherwise the adjusted offset will not be correct. This worked before due to ordering of version and checksum in test files and ordering of version and checksum in the heuristic that were matching.