### PR TITLE
Date update logic compares original versions

### DIFF
--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppBuilder.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/AppBuilder.kt
@@ -90,11 +90,12 @@ object AppBuilder {
       if (github) GithubClient.getClient(env, appConfig.baseBranch, appConfig.gitAuthor) else GitHostClient.stub
     val bazelRulesExtractor = BazelRulesExtractor()
     val bazelUpdater = BazelUpdater()
-    val githubRulesResolver = GithubRulesResolver(
+    val gitHubClient = (
       env["GITHUB_TOKEN"]
         ?.let(GitHub::connectUsingOAuth)
-        ?: GitHub.connectAnonymously(),
-    )
+        ?: GitHub.connectAnonymously()
+      )
+    val githubRulesResolver = GithubRulesResolver(gitHubClient)
     val fileFinder = FileFinder(appConfig.workspaceRoot)
 
     val dependencyKinds = listOf(

--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
@@ -59,9 +59,9 @@ class UpdateLogic {
     fun selectByDate(): UpdateSuggestion? {
       return library.version.toSemVer(updateRules.versioningSchema)
         ?.takeIf { version -> version.prerelease.isBlank() }
-        ?.let { libVersion ->
+        ?.let {
           maxAvailableVersionByDate()?.let {
-            if (it.value != libVersion.value) {
+            if (it.value != library.version.value) {
               UpdateSuggestion(library, it)
             } else {
               null

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/MavenTest.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/MavenTest.kt
@@ -15,7 +15,7 @@ class MavenTest : E2EBase() {
       "io.arrow-kt/arrow-core" to "1.1.5",
       "io.arrow-kt/arrow-fx-coroutines" to "1.1.5",
       "bazel" to "5.4.0",
-      "rules_jvm_external" to "5.1",
+      "rules_jvm_external" to "5.2",
       "rules_kotlin" to "v1.7.1",
       "bazel-skylib" to "1.4.1",
       "rules_scala" to "v5.0.0",


### PR DESCRIPTION
Before this PR, the version from server in raw form was compared to local version in semver form, resulting in comparing
"5.2" to "5.2.0"