### PR TITLE
Try harder to get valid downloadUrl for bazel rules

### DIFF
--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/App.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/App.kt
@@ -53,6 +53,7 @@ data class App(
           "Skipping this dependency kind..."
       }
       logger.warn("Error details: ${e.message}")
+      logger.debug(e) { "Full stacktrace" }
       null
     }
   }

--- a/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/fixture/E2EBase.kt
+++ b/e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/fixture/E2EBase.kt
@@ -219,8 +219,8 @@ open class E2EBase {
   }
 
   class GithubRulesResolverMock(private val expectedVersion: Version) : RulesResolver {
-    override fun resolveRuleVersions(ruleId: RuleLibraryId): Map<RuleLibraryId, Version> {
-      return mapOf(ruleId to expectedVersion)
+    override fun resolveRuleVersions(ruleId: RuleLibraryId): List<Version> {
+      return listOf(expectedVersion)
     }
   }
 }

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/BazelRulesDependencyKind.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/BazelRulesDependencyKind.kt
@@ -20,7 +20,7 @@ class BazelRulesDependencyKind(
   override suspend fun findAvailableVersions(workspaceRoot: Path): Map<RuleLibrary, List<Version>> {
     val usedBazelRules = bazelRulesExtractor.extractCurrentRules(workspaceRoot)
     return usedBazelRules
-      .associateWith { it: RuleLibrary -> rulesResolver.resolveRuleVersions(it.id).values.toList() }
+      .associateWith { it: RuleLibrary -> rulesResolver.resolveRuleVersions(it.id) }
   }
 
   override val defaultSearchPatterns: List<PathPattern> = listOf(

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/GithubRulesResolver.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/GithubRulesResolver.kt
@@ -1,39 +1,52 @@
 package org.virtuslab.bazelsteward.bazel.rules
 
-import org.kohsuke.github.GHAsset
 import org.kohsuke.github.GHRelease
 import org.kohsuke.github.GitHub
-import java.net.URL
-import java.security.DigestInputStream
-import java.security.MessageDigest
-import kotlin.math.min
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
 
 class GithubRulesResolver(private val gitHubClient: GitHub) : RulesResolver {
 
-  override fun resolveRuleVersions(ruleId: RuleLibraryId): Map<RuleLibraryId, RuleVersion> =
-    ruleId.toRepositoryId().listReleases().map { shaFromBodyAndCurrentUrl(ruleId, it) }.toMap()
-
-  private fun shaFromBodyAndCurrentUrl(ruleId: RuleLibraryId, release: GHRelease): Pair<RuleLibraryId, RuleVersion> {
-    return sha256Regex.findAll(release.body).map { it.value }.singleOrNull().let { sha ->
-      val newArtifactName = ruleId.artifactName.replace(ruleId.tag, release.tagName)
-      val rule = ruleId.copy(tag = release.tagName, artifactName = newArtifactName)
-      rule to RuleVersion.create(rule.downloadUrl, sha, release.tagName, release.published_at.toInstant())
-    }
+  override fun resolveRuleVersions(ruleId: RuleLibraryId): List<RuleVersion> {
+    val repositoryId = "${ruleId.repoName}/${ruleId.ruleName}"
+    val repository = gitHubClient.getRepository(repositoryId)
+    val releases = repository.listReleases()
+    return releases.map { toVersion(ruleId, it) }.toList()
   }
 
-  private fun RepositoryId.listReleases(): Sequence<GHRelease> =
-    gitHubClient.getRepository(this.toString()).listReleases().asSequence()
+  private fun toVersion(ruleId: RuleLibraryId, release: GHRelease): RuleVersion {
+    val sha = sha256Regex.findAll(release.body).map { it.value }.singleOrNull()
+    val downloadUrl = resolveUrl(ruleId, release)
+    return RuleVersion.create(downloadUrl, sha, release.tagName, release.published_at.toInstant())
+  }
+
+  private fun resolveUrl(ruleId: RuleLibraryId, release: GHRelease): String {
+    val newArtifactName = ruleId.artifactName.replace(ruleId.tag, release.tagName)
+    val defaultUrl = ruleId.copy(tag = release.tagName, artifactName = newArtifactName).downloadUrl
+
+    if (testUrl(defaultUrl)) {
+      return defaultUrl
+    }
+
+    val urlsFromAssets = release.assets().map { it.browserDownloadUrl }.asSequence()
+    val urlsFromBody = urlRegex.findAll(release.body).map { it.groupValues.first() }
+      .filterNot { urlsFromAssets.contains(it) }
+      .filter { testUrl(it) }
+    val urlCandidates = urlsFromAssets + urlsFromBody
+
+    return urlCandidates
+      .mapNotNull { runCatching { RuleLibraryId.from(it) }.getOrNull() }
+      .sortedBy { levenshtein(it.artifactName, ruleId.artifactName) }
+      .firstOrNull()?.downloadUrl
+      ?: defaultUrl // hope for the best
+  }
 
   companion object {
     private val sha256Regex = "\\b[A-Fa-f0-9]{64}\\b".toRegex()
-
-    private fun RuleLibraryId.toRepositoryId() = RepositoryId(repoName, ruleName)
-
-    private fun GHAsset.sha256() = URL(this.browserDownloadUrl).getFileChecksum(MessageDigest.getInstance("SHA-256"))
-
-    private data class RepositoryId(val user: String, val repository: String) {
-      override fun toString(): String = "$user/$repository"
-    }
+    private val urlRegex = """(?<=")(https://github\.com/.*?)(?=")""".toRegex()
 
     private fun RuleLibraryId.copy(
       tag: String,
@@ -50,74 +63,20 @@ class GithubRulesResolver(private val gitHubClient: GitHub) : RulesResolver {
           this.copy(tag = tag, artifactName = artifactName)
       }
     }
-
-    private fun levenshtein(lhs: CharSequence, rhs: CharSequence): Int {
-      if (lhs == rhs) {
-        return 0
-      }
-      if (lhs.isEmpty()) {
-        return rhs.length
-      }
-      if (rhs.isEmpty()) {
-        return lhs.length
-      }
-
-      val lhsLength = lhs.length + 1
-      val rhsLength = rhs.length + 1
-
-      var cost = Array(lhsLength) { it }
-      var newCost = Array(lhsLength) { 0 }
-
-      for (i in 1 until rhsLength) {
-        newCost[0] = i
-
-        for (j in 1 until lhsLength) {
-          val match = if (lhs[j - 1] == rhs[i - 1]) 0 else 1
-
-          val costReplace = cost[j - 1] + match
-          val costInsert = cost[j] + 1
-          val costDelete = newCost[j - 1] + 1
-
-          newCost[j] = min(min(costInsert, costDelete), costReplace)
-        }
-
-        val swap = cost
-        cost = newCost
-        newCost = swap
-      }
-
-      return cost[lhsLength - 1]
-    }
-
-    internal fun URL.getFileChecksum(digest: MessageDigest): String {
-      var messageDigest: MessageDigest
-      DigestInputStream(this.openStream(), digest).use { dis ->
-        while (dis.read() != -1);
-        messageDigest = dis.messageDigest
-      }
-
-      val result = StringBuilder()
-      for (b in messageDigest.digest()) {
-        result.append(String.format("%02x", b))
-      }
-      return result.toString()
-    }
   }
 }
 
-// override fun resolveRuleVersions(ruleId: BazelRuleLibraryId): Map<BazelRuleLibraryId, Version> =
-//  ruleId.toRepositoryId().listReleases().associateWith { release ->
-//    val shas = sha256Regex.findAll(release.body).map { it.value }.toList()
-//    val assets = release.listAssets().toList()
-//    if (assets.size > 1) {
-//      return@associateWith assets
-//        .sortedBy { GithubRulesResolver.levenshtein(it.name, ruleId.artifactName) }
-//        .asSequence()
-//        .map { it to it.sha256() }
-//        .firstOrNull { shas.contains(it.second) }
-//        ?.let { ruleId.copy(url = it.first.browserDownloadUrl, sha256 = it.second) }
-//    }
-//    assets.singleOrNull()?.let {
-//      ruleId.copy(url = it.browserDownloadUrl, sha256 = shas.singleOrNull() ?: it.sha256())
-//    }
-//  }.filterValues { it != null }.map { it.value!! to SimpleVersion(it.key.tagName) }.toMap()
+private fun testUrl(url: String): Boolean {
+  val httpClient = HttpClient.newBuilder()
+    .connectTimeout(Duration.ofSeconds(10))
+    .build()
+  return runCatching {
+    val uri = URI.create(url)
+    val requestHead = HttpRequest.newBuilder()
+      .method("HEAD", HttpRequest.BodyPublishers.noBody())
+      .uri(uri)
+      .build()
+    val httpResponse = httpClient.send(requestHead, HttpResponse.BodyHandlers.discarding())
+    return httpResponse.statusCode() < 300
+  }.getOrNull() ?: false
+}

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/Levenshtein.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/Levenshtein.kt
@@ -1,0 +1,41 @@
+package org.virtuslab.bazelsteward.bazel.rules
+
+import kotlin.math.min
+
+internal fun levenshtein(lhs: CharSequence, rhs: CharSequence): Int {
+  if (lhs == rhs) {
+    return 0
+  }
+  if (lhs.isEmpty()) {
+    return rhs.length
+  }
+  if (rhs.isEmpty()) {
+    return lhs.length
+  }
+
+  val lhsLength = lhs.length + 1
+  val rhsLength = rhs.length + 1
+
+  var cost = Array(lhsLength) { it }
+  var newCost = Array(lhsLength) { 0 }
+
+  for (i in 1 until rhsLength) {
+    newCost[0] = i
+
+    for (j in 1 until lhsLength) {
+      val match = if (lhs[j - 1] == rhs[i - 1]) 0 else 1
+
+      val costReplace = cost[j - 1] + match
+      val costInsert = cost[j] + 1
+      val costDelete = newCost[j - 1] + 1
+
+      newCost[j] = min(min(costInsert, costDelete), costReplace)
+    }
+
+    val swap = cost
+    cost = newCost
+    newCost = swap
+  }
+
+  return cost[lhsLength - 1]
+}

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/RuleVersion.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/RuleVersion.kt
@@ -1,9 +1,7 @@
 package org.virtuslab.bazelsteward.bazel.rules
 
-import org.virtuslab.bazelsteward.bazel.rules.GithubRulesResolver.Companion.getFileChecksum
 import org.virtuslab.bazelsteward.core.library.Version
 import java.net.URL
-import java.security.MessageDigest
 import java.time.Instant
 
 @Suppress("CanBeParameter")
@@ -20,11 +18,19 @@ sealed class RuleVersion(val url: String, val tag: String, override val date: In
       }
     }
 
-    private class RuleVersionEager(url: String, override val sha256: String, tag: String, override val date: Instant?) : RuleVersion(url, tag, date)
-    private class RuleVersionLazy(url: String, tag: String, override val date: Instant?) : RuleVersion(url, tag, date) {
-      override val sha256: String by lazy {
-        URL(url).getFileChecksum(MessageDigest.getInstance("SHA-256"))
-      }
+    private class RuleVersionEager(
+      url: String,
+      override val sha256: String,
+      tag: String,
+      override val date: Instant?,
+    ) : RuleVersion(url, tag, date)
+
+    private class RuleVersionLazy(
+      url: String,
+      tag: String,
+      override val date: Instant?,
+    ) : RuleVersion(url, tag, date) {
+      override val sha256: String by lazy { computeSha256(URL(url)) }
     }
   }
 }

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/RulesResolver.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/RulesResolver.kt
@@ -3,5 +3,5 @@ package org.virtuslab.bazelsteward.bazel.rules
 import org.virtuslab.bazelsteward.core.library.Version
 
 interface RulesResolver {
-  fun resolveRuleVersions(ruleId: RuleLibraryId): Map<RuleLibraryId, Version>
+  fun resolveRuleVersions(ruleId: RuleLibraryId): List<Version>
 }

--- a/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/Sha256.kt
+++ b/kinds/bazel/rules/src/main/kotlin/org/virtuslab/bazelsteward/bazel/rules/Sha256.kt
@@ -1,0 +1,20 @@
+package org.virtuslab.bazelsteward.bazel.rules
+
+import java.net.URL
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+internal fun computeSha256(url: URL): String {
+  val digest = MessageDigest.getInstance("SHA-256")
+  var messageDigest: MessageDigest
+  DigestInputStream(url.openStream(), digest).use { dis ->
+    while (dis.read() != -1);
+    messageDigest = dis.messageDigest
+  }
+
+  val result = StringBuilder()
+  for (b in messageDigest.digest()) {
+    result.append(String.format("%02x", b))
+  }
+  return result.toString()
+}


### PR DESCRIPTION
Naively generated URL (by just replacing version in old library name) is tested with HEAD request. If it fails, Bazel Steward will try to find best match from assets attached. to the release and https://github.com urls from body. URLs from body are also tested with HEAD. Artifact names are sorted by levenstein distance to original artifact name.