### PR TITLE
Added the pieces that were accidentally omitted when moving the documentation to the Jekyll site.

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -43,6 +43,9 @@ search-paths:
       - ".bazelversion"
       - ".github/**/*.yaml"
 pull-requests:
+  -   
+    dependencies: "com.fasterxml.jackson*:*"
+    group-id: jackson
   - 
     title: "[maintenance] Updated ${group}/${artifact} from ${versionFrom} to ${versionTo}"
     kinds: maven

--- a/docs/docs/getting-bazel-steward.md
+++ b/docs/docs/getting-bazel-steward.md
@@ -10,13 +10,13 @@ Bazel Steward is published to Maven Central under `org.virtuslab:bazel-steward`.
 To easily run it, use [Coursier](https://get-coursier.io/docs/cli-installation).
 
 ```
-coursier launch org.virtuslab:bazel-steward:0.2.11 --main org.virtuslab.bazelsteward.app.Main -- --help
+coursier launch org.virtuslab:bazel-steward:0.2.18 --main org.virtuslab.bazelsteward.app.Main -- --help
 ```
 
 ### GitHub Releases
 Bazel Steward publishes a fat JAR under GitHub Releases. The same JAR is also used in GitHub Actions. You can simply download it and run using the `java` command.
 
 ```
-wget https://github.com/VirtusLab/bazel-steward/releases/download/v0.2.11/bazel-steward.jar
+wget https://github.com/VirtusLab/bazel-steward/releases/download/v0.2.18/bazel-steward.jar
 java -jar bazel-steward.jar --help
 ```

--- a/docs/docs/usage/rules.md
+++ b/docs/docs/usage/rules.md
@@ -49,7 +49,11 @@ When the rule is found, it can configure for a dependency the following things:
   * `limits` (object) <br/>
       - `max-open` (number): maximum allowed number of open pull requests in the repository. Useful if you have 100 outdated dependencies and you would like to have just 10 open, merge them in your own pace, and Bazel Steward will add new pull requests up to this limit.
       - max-updates-per-run (number): maximum number of updated pull requests per Bazel Steward run. It includes both creating new PRs and resolving conflicts on existing ones. This is useful if your CI that runs on push is costly and you would like to limit the runs.
-      
+  * `group-id` (string) <br/>
+    Enables grouping for dependencies matching filter (specified by `dependencies` and/or `kinds` keys).
+    This id will be used in branch name, pull request title and commit message.
+    Note: Use this only for dependencies that are released together under the same version. Other scenarios might have unexpected results.
+	  
 * In `post-update-hooks` section:
   * `commands` (list of strings) <br/>
     List of commands to run after applying an update. Commands are run separately under `sh -c`


### PR DESCRIPTION
These changes come from commits e81caeee04fffa7946af96e67c24ef4a715e3ff5 and d8923957545e311bf961fd0d1aa8939d89aab2ef.