### PR TITLE
Add bumping strategy that allows skipping major updates

### DIFF
--- a/app/src/test/kotlin/org/virtuslab/bazelsteward/app/UpdateLogicTest.kt
+++ b/app/src/test/kotlin/org/virtuslab/bazelsteward/app/UpdateLogicTest.kt
@@ -40,7 +40,7 @@ class UpdateLogicTest {
   @MethodSource("argumentsForSelectUpdateDefault")
   fun `should selectUpdate test with default bumping strategy`(version: String, suggestion: String?) {
     val coordinates = MavenCoordinates.of("group", "artifact", version)
-    val updateRules = UpdateRules(bumpingStrategy = BumpingStrategy.Patch)
+    val updateRules = UpdateRules(bumpingStrategy = BumpingStrategy.Minimal)
     val updateSuggestion = UpdateLogic().selectUpdate(coordinates, availableVersions, updateRules)
     Assertions.assertThat(updateSuggestion?.suggestedVersion?.value).isEqualTo(suggestion)
   }
@@ -101,12 +101,12 @@ class UpdateLogicTest {
   }
 
   private fun argumentsForSelectUpdateMix(): List<Arguments> = listOf(
-    Arguments.of("g1", "a1", "2.0.0", "2.0.2", VersioningSchema.Loose, BumpingStrategy.Patch),
-    Arguments.of("g1", "a4", "2.0.2+beta", "2.3.3+beta", VersioningSchema.Loose, BumpingStrategy.Patch),
-    Arguments.of("g2", "a1", "2.0.2", "2.3.3+beta", VersioningSchema.SemVer, BumpingStrategy.Patch),
+    Arguments.of("g1", "a1", "2.0.0", "2.0.2", VersioningSchema.Loose, BumpingStrategy.Minimal),
+    Arguments.of("g1", "a4", "2.0.2+beta", "2.3.3+beta", VersioningSchema.Loose, BumpingStrategy.Minimal),
+    Arguments.of("g2", "a1", "2.0.2", "2.3.3+beta", VersioningSchema.SemVer, BumpingStrategy.Minimal),
     Arguments.of("g2", "a2", "3.0.1", "4.0.2", VersioningSchema.Loose, BumpingStrategy.Latest),
     Arguments.of("g3", "a1", "2.1.0+beta", "4.0.2", VersioningSchema.Loose, BumpingStrategy.Latest),
-    Arguments.of("g3", "a3", "2.3.2+beta", "2.3.3+beta", VersioningSchema.Loose, BumpingStrategy.Patch),
+    Arguments.of("g3", "a3", "2.3.2+beta", "2.3.3+beta", VersioningSchema.Loose, BumpingStrategy.Minimal),
     Arguments.of("g3", "a5", "3.0.0+beta", "4.0.2", VersioningSchema.Loose, BumpingStrategy.Latest),
   )
 

--- a/app/src/test/kotlin/org/virtuslab/bazelsteward/app/UpdateRulesProviderTest.kt
+++ b/app/src/test/kotlin/org/virtuslab/bazelsteward/app/UpdateRulesProviderTest.kt
@@ -32,7 +32,7 @@ class UpdateRulesProviderTest {
 
     val result = rulesProvider.resolveForLibrary(library)
 
-    result.bumpingStrategy shouldBe BumpingStrategy.Patch
+    result.bumpingStrategy shouldBe BumpingStrategy.Minimal
   }
 
   @Test
@@ -66,7 +66,7 @@ class UpdateRulesProviderTest {
     fun shouldApplyGeneralRules(library: Library) {
       val rules = rulesProvider.resolveForLibrary(library)
       rules.pinningStrategy shouldBe PinningStrategy.None
-      rules.bumpingStrategy shouldBe BumpingStrategy.Patch
+      rules.bumpingStrategy shouldBe BumpingStrategy.Minimal
       rules.versioningSchema shouldBe VersioningSchema.SemVer
     }
 

--- a/app/src/test/resources/example-config.yaml
+++ b/app/src/test/resources/example-config.yaml
@@ -10,7 +10,7 @@ update-rules:
     kinds: maven
     versioning: semver
   -
-    bumping: patch
+    bumping: minimal
 search-paths:
   -
     dependencies:

--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/UpdateLogic.kt
@@ -10,7 +10,7 @@ data class UpdateSuggestion(val currentLibrary: Library, val suggestedVersion: V
 
 data class UpdateRules(
   val versioningSchema: VersioningSchema = VersioningSchema.Loose,
-  val bumpingStrategy: BumpingStrategy = BumpingStrategy.Minor,
+  val bumpingStrategy: BumpingStrategy = BumpingStrategy.MinorPatchMajor,
   val pinningStrategy: PinningStrategy = PinningStrategy.None,
   val enabled: Boolean = true,
 )
@@ -43,9 +43,12 @@ class UpdateLogic {
           val maxMinor = maxAvailableVersion { a -> a.major == version.major && a.minor > version.minor }
           val maxMajor = maxAvailableVersion { a -> a.major > version.major }
           val nextVersion = when (updateRules.bumpingStrategy) {
-            BumpingStrategy.Patch -> maxPatch ?: maxMinor ?: maxMajor
+            BumpingStrategy.Minimal -> maxPatch ?: maxMinor ?: maxMajor
             BumpingStrategy.Latest -> maxMajor ?: maxMinor ?: maxPatch
-            BumpingStrategy.Minor -> maxMinor ?: maxPatch ?: maxMajor
+            BumpingStrategy.MinorPatchMajor -> maxMinor ?: maxPatch ?: maxMajor
+            BumpingStrategy.PatchOnly -> maxPatch
+            BumpingStrategy.PatchMinor -> maxPatch ?: maxMinor
+            BumpingStrategy.MinorPatch -> maxMinor ?: maxPatch
             else -> null
           }
           nextVersion?.let { UpdateSuggestion(library, it) }

--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/library/BumpingStrategy.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/library/BumpingStrategy.kt
@@ -1,5 +1,5 @@
 package org.virtuslab.bazelsteward.core.library
 
 enum class BumpingStrategy {
-  Patch, Latest, Minor, LatestByDate
+  Minimal, Latest, MinorPatchMajor, LatestByDate, PatchOnly, PatchMinor, MinorPatch
 }

--- a/docs/docs/configuration/configuration-file/index.md
+++ b/docs/docs/configuration/configuration-file/index.md
@@ -27,7 +27,7 @@ update-rules:
     kinds: maven
     dependencies: commons-io:commons-io
     versioning: loose
-    bumping: patch
+    bumping: minimal
     pin: "2.0."
   -
     dependencies: io.get-coursier:interface

--- a/docs/docs/configuration/configuration-file/update-rules.md
+++ b/docs/docs/configuration/configuration-file/update-rules.md
@@ -16,7 +16,7 @@ update-rules:
     kinds: maven
     dependencies: commons-io:commons-io
     versioning: loose
-    bumping: patch
+    bumping: minimal
     pin: "2.0."
   -
     dependencies: io.get-coursier:interface
@@ -39,7 +39,7 @@ Available fields:
     Default: `loose`. Allowed values:  
     - `semver` - parse version strictly  following [Semantic Versioning](https://semver.org/) schema
     - `loose` - less constrained regex that will try to catch most popular versioning strategies that do not strictly conform to semver (but it works correctly with semver versions too)
-    - `regex:...` - use custom regex for parsing the version. Useful for libraries with very non standard schema.
+    - `regex:...` - use custom regex for parsing the version. Useful for libraries with very non-standard schema.
   * `pin` (string) <br/>
     Filters versions that are allowed for the dependency.
     It can be an exact version, prefix or regular expression.
@@ -47,10 +47,13 @@ Available fields:
     You can override this by prepending the value with `prefix:`, `exact:` or `regex:`.
   * `bumping` (string) <br/>
     Sets the strategy for bumping this dependency.
-    1. `latest` - Always bump to the latest version.
-    2. `patch` - First bump to the latest patch, then to the latest minor, and then finally to the latest major.
-    3. `minor` - First bump to the latest minor, if there is no such update, bump the latest patch otheriwse bump the major.
-    4. `latest-by-date` - Always bump to the most recently released version even if the version is lower then currently used.
+    1. `latest` - Always bump to the highest version.
+    2. `minimal` - First bump to the latest patch, then to the latest minor, and then finally to the latest major.
+    3. `minor-patch-major` - First bump to the latest minor, if there is no such update, bump the latest patch otherwise bump the major.
+    4. `latest-by-date` - Always bump to the most recently released version even if the version is lower than currently used.
+    5. `patch-only` - Bump only patch versions, never upgrade by major or minor version.
+    6. `patch-minor` - First bump to the latest patch, then to the latest minor. Do not bump major.
+    7. `minor-patch` - First bump to the latest minor version, if not possible try bumping the patch version. Never bump major.
   * `enabled` (boolean) <br/>
     If set to false, Bazel Steward will ignore this dependency for available versions lookup and any updates.
     If this is set for `kinds` only filter, then it will disable the specified kind - Bazel Steward will not attempt 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -109,13 +109,13 @@ Bazel Steward is published to Maven Central under `org.virtuslab:bazel-steward`.
 To easily run it, use [Coursier](https://get-coursier.io/docs/cli-installation).
 
 ```
-coursier launch org.virtuslab:bazel-steward:1.2.0 --main org.virtuslab.bazelsteward.app.Main -- --help
+coursier launch org.virtuslab:bazel-steward:1.3.0 --main org.virtuslab.bazelsteward.app.Main -- --help
 ```
 
 ## GitHub Releases
 Bazel Steward publishes a fat JAR under GitHub Releases. The same JAR is also used in GitHub Actions. You can simply download it and run using the `java` command.
 
 ```
-wget https://github.com/VirtusLab/bazel-steward/releases/download/v1.2.0/bazel-steward.jar
+wget https://github.com/VirtusLab/bazel-steward/releases/download/v1.3.0/bazel-steward.jar
 java -jar bazel-steward.jar --help
 ```

--- a/repo-config/src/main/resources/repo-config-schema.json
+++ b/repo-config/src/main/resources/repo-config-schema.json
@@ -27,7 +27,7 @@
           },
           "bumping": {
             "type": ["string", "null"],
-            "enum": ["patch", "latest", "minor", "latest-by-date"]
+            "enum": ["minimal", "latest", "minor-patch-major", "latest-by-date", "patch-only", "patch-minor", "minor-patch"]
           },
           "enabled": {
             "type": ["boolean", "null"]

--- a/repo-config/src/test/kotlin/org/virtuslab/bazelsteward/config/repo/RepoConfigurationTest.kt
+++ b/repo-config/src/test/kotlin/org/virtuslab/bazelsteward/config/repo/RepoConfigurationTest.kt
@@ -24,7 +24,7 @@ class RepoConfigurationTest {
           "update-rules[0].dependenciess: is not defined in the schema and the schema does not allow additional properties",
           "update-rules[1].versioning: does not have a value in the enumeration [loose, semver]",
           "update-rules[1].versioning: does not match the regex pattern ^regex:",
-          "update-rules[1].bumping: does not have a value in the enumeration [patch, latest, minor, latest-by-date]",
+          "update-rules[1].bumping: does not have a value in the enumeration [minimal, latest, minor-patch-major, latest-by-date, patch-only, patch-minor, minor-patch]",
           "update-rules[2].kinds[0]: integer found, string expected",
         ).joinToString(System.lineSeparator()),
       )
@@ -46,7 +46,7 @@ class RepoConfigurationTest {
           kinds = listOf("maven"),
           dependencies = listOf(DependencyNameFilter.Default("commons-io:commons-io")),
           versioning = VersioningSchema.Loose,
-          bumping = BumpingStrategy.Patch,
+          bumping = BumpingStrategy.Minimal,
           pin = PinningStrategy.Prefix("2.0."),
         ),
         UpdateRulesConfig(

--- a/repo-config/src/test/resources/.bazel-steward-correct.yaml
+++ b/repo-config/src/test/resources/.bazel-steward-correct.yaml
@@ -3,7 +3,7 @@ update-rules:
     kinds: maven
     dependencies: commons-io:commons-io
     versioning: loose
-    bumping: patch
+    bumping: minimal
     pin: 2.0.
   -
     dependencies: io.get-coursier:interface


### PR DESCRIPTION
Breaking change: Bumping strategy "patch" is now "minimal"