### PR TITLE
Group libraries with the same id.value under one PR

### DIFF
--- a/app/src/main/kotlin/org/virtuslab/bazelsteward/app/provider/PullRequestConfigProvider.kt
+++ b/app/src/main/kotlin/org/virtuslab/bazelsteward/app/provider/PullRequestConfigProvider.kt
@@ -10,18 +10,18 @@ class PullRequestConfigProvider(
   private val configs: List<PullRequestsConfig>,
   dependencyKinds: List<DependencyKind<*>>,
 ) {
-  private val applier = DependencyFilterApplier(configs, dependencyKinds)
+  private val filter = DependencyFilterApplier(configs, dependencyKinds)
 
   fun resolveGroup(library: Library): GroupId? {
-    return applier.forLibrary(library).findNotNullOrDefault(null) { it.groupId }
+    return filter.forLibrary(library).findNotNullOrDefault(null) { it.groupId }
   }
 
   fun resolveForGroup(groupId: GroupId): PullRequestConfig {
-    return resolveFromFilter(applier.forPredicate { it.groupId == groupId })
+    return resolveFromFilter(filter.forPredicate { it.groupId == groupId })
   }
 
   fun resolveForLibrary(library: Library): PullRequestConfig {
-    return resolveFromFilter(applier.forLibrary(library))
+    return resolveFromFilter(filter.forLibrary(library))
   }
 
   private fun resolveFromFilter(filter: DependencyFilterApplier.Filtered<PullRequestsConfig>): PullRequestConfig {


### PR DESCRIPTION
There might be libraries, (especially cough by bazel-rules kind) that have multiple artifacts and are detected as separate libraries, but with the sama name (but different artifact name). These are now grouped together under one PR with multiple commits to update each variant. Example is http_archive for 4 different platforms.