### PR TITLE
More robust bzlmod version extraction

### DIFF
--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/CommandRunner.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/CommandRunner.kt
@@ -19,8 +19,16 @@ class CommandRunner {
       return runForOutput(command.toList(), directory)
     }
 
-    suspend fun runForOutput(command: List<String>, directory: Path? = null): String {
+    suspend fun runForOutput(command: List<String>, directory: Path? = null, continueOnFailure: Boolean = false): String {
       val result = run(command, directory)
+
+      if (continueOnFailure) {
+        if (!result.isSuccess) {
+          logger.warn("Ignoring failure (code ${result.exitCode}) of:\n${command.joinToString(" ")}\n${result.stderr}")
+        }
+        return result.stdout
+      }
+
       if (result.isSuccess) {
         return result.stdout
       } else {

--- a/kinds/bzlmod/src/main/kotlin/org/virtuslab/bazelsteward/bzlmod/BzlModDataExtractor.kt
+++ b/kinds/bzlmod/src/main/kotlin/org/virtuslab/bazelsteward/bzlmod/BzlModDataExtractor.kt
@@ -53,7 +53,11 @@ class BzlModDataExtractor(
   }
 
   private suspend fun findDependencies(): List<BazelModule> = withContext(Dispatchers.IO) {
-    val output = CommandRunner.runForOutput(workspaceRoot, "bazel", "mod", "graph", "--depth=1")
+    val output = CommandRunner.runForOutput(
+      listOf("bazel", "mod", "graph", "--depth=1"),
+      workspaceRoot,
+      continueOnFailure = true,
+    )
     return@withContext regexPattern.findAll(output).mapNotNull {
       val name = it.groups[1]!!.value.trim()
       val version = it.groups[2]!!.value.trim()


### PR DESCRIPTION
bazel mod command can fail but still print some versions which we can work with on best effort basis