### PR TITLE
docs: Update actions/checkout version in Installation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -30,7 +30,7 @@ jobs:
   bazel-steward:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: VirtusLab/bazel-steward@latest


### PR DESCRIPTION
Because ancient (@v2) version of GitHub actions can cause problems like https://github.com/MariaDB4j/MariaDB4j/issues/1107 due to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.