### PR TITLE
docs: Do not recommand using @latest in Installation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: VirtusLab/bazel-steward@latest
+      - uses: VirtusLab/bazel-steward@...
         with:
           github-personal-token: 'XXXXXXXXXXXXXXXXXX' # used for triggering workflows, read below
 ```


### PR DESCRIPTION
In my humble opinion (IMHO), recommending that users who adopt Bazel Steward depend on its GitHub Action with `VirtusLab/bazel-steward@latest` is not a good advice - because `@latest` is a "moving target", not a stable fixed version.

Especially for an (awesome, great!) tool like Bazel Steward, who's purpose of being is very much helping people to have stable reliable builds, while still getting automagic version bumps to move external dependencies along, it should not recommend this.