### PR TITLE
Remove extra 'git' from git diff command which results in always fail

### DIFF
--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/GitOperations.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/common/GitOperations.kt
@@ -87,7 +87,7 @@ class GitOperations(repositoryRoot: Path, private val baseBranch: String) {
 
   suspend fun commitSelectedFiles(filesToCommit: List<String>, commitMessage: String) {
     git.add(filesToCommit)
-    val noChanges = git.runForResult("git", "diff", "--quiet", "--exit-code", "--cached").isSuccess
+    val noChanges = git.runForResult("diff", "--quiet", "--exit-code", "--cached").isSuccess
     if (noChanges) {
       logger.warn { "No changes to commit" }
     } else {


### PR DESCRIPTION
fixes #426