### PR TITLE
Don't quote `configuration-path` in `action.yaml`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
     - name: Run bazel steward
       run: |
         NO_REMOTE=$([[ $PUSH_TO_REMOTE == 'true' ]] && echo "" || echo "--no-remote")
-        CONFIG_PATH_ARG=$([[ -n "${{ inputs.configuration-path }}" ]] && echo "--config-path '${{ inputs.configuration-path }}'" || echo "")
+        CONFIG_PATH_ARG=$([[ -n "${{ inputs.configuration-path }}" ]] && echo "--config-path ${{ inputs.configuration-path }}" || echo "")
         java -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO -jar /tmp/bazel-steward.jar \
         --github $NO_REMOTE $CONFIG_PATH_ARG ${{ inputs.additional-args }}
       shell: bash


### PR DESCRIPTION
Quoting is weird. This instance resulted in the value of `--config-path` always being enclosed in single-quotes and with the new config path existence check resulting in:

```
Error: Exception in thread "main" java.lang.RuntimeException: Requested config file ''./.github/bazel-steward.yaml'' does not exist
```