### PR TITLE
chore: modernize release pipeline and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,60 +6,109 @@ on:
       - "v*.*.*"
     branches: [ main ]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
 jobs:
   tagged-release:
-    runs-on: "ubuntu-latest"
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bazel build //app:app_deploy.jar
-        name: Build project and jar
-      - run: mv bazel-bin/app/app_deploy.jar bazel-steward.jar
-        name: Rename jar
-      - uses: marvinpinto/action-automatic-releases@v1.2.1
-        name: Publish
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ github.ref_type != 'tag' }}
-          title: ${{ github.ref_type != 'tag' && 'Development Build' || null }}
-          automatic_release_tag: ${{ github.ref_type != 'tag' && 'latest' || null }}
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-release-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'maven_install.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-release-
+            ${{ runner.os }}-bazel-
+      - name: Build deploy jar
+        run: bazel build //app:app_deploy.jar
+      - name: Stage jar
+        run: cp bazel-bin/app/app_deploy.jar bazel-steward.jar
+      - name: Publish tagged release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
           files: bazel-steward.jar
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+      - name: Publish rolling "latest" pre-release
+        if: github.ref_type != 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: bazel-steward.jar
+          fail_on_unmatched_files: true
+          name: Development Build
+          tag_name: latest
+          prerelease: true
+
   maven-release:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
+    needs: tagged-release
     if: github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-release-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'maven_install.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-release-
+            ${{ runner.os }}-bazel-
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}
-      - run: |
-          RELEASE_VERSION="${GITHUB_REF#refs/*/v}" ./tools/publish/publish.sh
+      - name: Release to Maven Central
+        run: RELEASE_VERSION="${GITHUB_REF#refs/*/v}" ./tools/publish/publish.sh
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        name: "Release to maven central"
+
   prefix-version-tag:
-    runs-on: "ubuntu-latest"
-    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
     needs: tagged-release
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: |
-          set -x
-          GIT_TAG=$(echo "${{ github.event.ref }}" | grep -Eo 'v[\.0-9]*')
+      - name: Update vMAJOR / vMAJOR.MINOR tags
+        run: |
+          set -euo pipefail
+          GIT_TAG="${GITHUB_REF#refs/tags/}"
           MINOR_TAG=$(echo "$GIT_TAG" | grep -Eo 'v[0-9]+\.[0-9]+')
           MAJOR_TAG=$(echo "$GIT_TAG" | grep -Eo 'v[0-9]+')
-          for TAG in "$MINOR_TAG" "$MAJOR_TAG"
-          do
-            TAG_LATEST=$(git ls-remote --tags | grep -Eo "v[0-9]+\.[0-9]+\.[0-9]+" | grep -E "$TAG" | sort -Vr | head -n 1)
-            if [ "$GIT_TAG" == "$TAG_LATEST" ]; then
+          for TAG in "$MINOR_TAG" "$MAJOR_TAG"; do
+            TAG_LATEST=$(git ls-remote --tags origin \
+              | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | grep -E "^${TAG}\." \
+              | sort -Vr | head -n 1 || true)
+            if [ "$GIT_TAG" = "$TAG_LATEST" ]; then
               git tag -f "$TAG" "$GIT_TAG"
-              git push -f origin "$TAG"
+              git push -f origin "refs/tags/$TAG"
             fi
           done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,66 +6,77 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: '17'
       - name: Cache Bazel
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          key: ${{ runner.os }}-bazel-unit-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'maven_install.json') }}
           restore-keys: |
+            ${{ runner.os }}-bazel-unit-
             ${{ runner.os }}-bazel-
-      - name: Run tests
+      - name: Run unit tests
         run: bazel test //... --keep_going --test_tag_filters=unit
-        env:
-          GITHUB_TOKEN: ${{ inputs.github-token }}
+
   integration-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: '17'
       - name: Cache Bazel
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          key: ${{ runner.os }}-bazel-integration-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'maven_install.json') }}
           restore-keys: |
+            ${{ runner.os }}-bazel-integration-
             ${{ runner.os }}-bazel-
-      - name: Run tests
+      - name: Run integration tests
         run: bazel test //... --keep_going --test_tag_filters=integration
+
   klint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: '17'
       - name: Cache Bazel
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          key: ${{ runner.os }}-bazel-lint-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel', 'maven_install.json') }}
           restore-keys: |
+            ${{ runner.os }}-bazel-lint-
             ${{ runner.os }}-bazel-
-      - name: Run tests
+      - name: Run lint
         run: bazel test //... --keep_going --test_output=errors --test_tag_filters=lint
+
   docker-build-test:
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +88,7 @@ jobs:
         with:
           use-release: "false"
           push-to-remote: "false"
+
   buildifier:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-FROM ubuntu:22.04 AS builder
-RUN apt-get update
-RUN apt install -y build-essential
-RUN apt-get install -y wget
-RUN apt install -y openjdk-17-jdk openjdk-17-jre
-RUN wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
-RUN chmod 733 bazelisk-linux-amd64
-COPY . .
-RUN ./bazelisk-linux-amd64 build //app:app_deploy.jar
+FROM ubuntu:24.04 AS builder
 
-FROM alpine:3.16
-COPY --from=builder bazel-bin/app/app_deploy.jar /opt/bazel-steward.jar
+ARG BAZELISK_VERSION=v1.22.1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        wget \
+        openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO /usr/local/bin/bazelisk \
+        "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64" \
+ && chmod 0755 /usr/local/bin/bazelisk
+
+WORKDIR /src
+COPY . .
+RUN /usr/local/bin/bazelisk build //app:app_deploy.jar
+
+FROM alpine:3.20
+COPY --from=builder /src/bazel-bin/app/app_deploy.jar /opt/bazel-steward.jar
 ENTRYPOINT ["cp", "/opt/bazel-steward.jar", "."]

--- a/action.yaml
+++ b/action.yaml
@@ -25,23 +25,27 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: '17'
     - name: Download release
       if: ${{ inputs.use-release == 'true' }}
       run: |
-        TAG_PATTERN=$(echo "${{ github.action_path }}" | grep -Po "(?<=\/)[^\/]*$")
-        if [[ $TAG_PATTERN == v* ]] ;
-        then
-          TAG_NAME=$(gh release list -L 100 --repo $REPOSITORY | grep -Eo '^'"$TAG_PATTERN"'[\.0-9]*' | sort -Vr | head -n 1)
+        set -euo pipefail
+        TAG_PATTERN="$(basename "${{ github.action_path }}")"
+        if [[ "$TAG_PATTERN" == v* ]]; then
+          # Resolve e.g. "v1" or "v1.7" to the highest matching vX.Y.Z tag.
+          TAG_NAME=$(gh release list -L 100 --repo "$REPOSITORY" \
+            --json tagName --jq '.[].tagName' \
+            | grep -E "^${TAG_PATTERN}(\.[0-9]+)*$" \
+            | sort -Vr | head -n 1)
         else
-          TAG_NAME=$TAG_PATTERN
+          TAG_NAME="$TAG_PATTERN"
         fi
-        echo $TAG_NAME
-        gh release download $TAG_NAME --pattern bazel-steward.jar --repo $REPOSITORY
+        echo "Resolved release tag: $TAG_NAME"
+        gh release download "$TAG_NAME" --pattern bazel-steward.jar --repo "$REPOSITORY"
       env:
         GH_TOKEN: ${{ github.token }}
         REPOSITORY: VirtusLab/bazel-steward

--- a/tools/publish/publish.sh
+++ b/tools/publish/publish.sh
@@ -1,25 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Publish the bazel-steward jar to Maven Central.
+#
+# OSSRH (oss.sonatype.org) was sunset on 2025-06-30 and replaced by the
+# Central Publisher Portal. Sonatype provides an OSSRH-compatible staging
+# API at https://ossrh-staging-api.central.sonatype.com so that existing
+# Nexus 2 tooling (like bazel_sonatype) continues to work. After upload,
+# the deployment must be released via the Portal UI or Portal API.
+#
+# See: https://central.sonatype.org/pages/ossrh-eol/
+
+readonly CENTRAL_PORTAL_API="https://ossrh-staging-api.central.sonatype.com/service/local"
+readonly BUILD_FILE="app/BUILD.bazel"
+
 if [ "${1:-}" == "--local" ]; then
   bazel run --stamp \
     --define "maven_repo=file://$HOME/.m2/repository" \
     //app:maven.publish
-else
-  : "$PGP_SECRET"
-  : "$PGP_PASSPHRASE"
-  : "$RELEASE_VERSION"
-
-  if [[ $(uname -s) == "Darwin" ]]; then
-    sed -i "" "s/0\.0\.0/$RELEASE_VERSION/g" app/BUILD.bazel
-  else
-    sed -i "s/0\.0\.0/$RELEASE_VERSION/g" app/BUILD.bazel
-  fi
-
-  bazel run --stamp \
-    --define "maven_repo=https://oss.sonatype.org/service/local" \
-    --define "maven_user=$SONATYPE_USERNAME" \
-    --define "maven_password=$SONATYPE_PASSWORD" \
-    //app:maven.publish
+  exit 0
 fi
 
+: "${PGP_SECRET:?PGP_SECRET is required}"
+: "${PGP_PASSPHRASE:?PGP_PASSPHRASE is required}"
+: "${RELEASE_VERSION:?RELEASE_VERSION is required}"
+: "${SONATYPE_USERNAME:?SONATYPE_USERNAME is required (Portal user token name)}"
+: "${SONATYPE_PASSWORD:?SONATYPE_PASSWORD is required (Portal user token pass)}"
+
+restore_build_file() {
+  if [ -f "${BUILD_FILE}.bak" ]; then
+    mv "${BUILD_FILE}.bak" "${BUILD_FILE}"
+  fi
+}
+trap restore_build_file EXIT
+
+cp "${BUILD_FILE}" "${BUILD_FILE}.bak"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  sed -i "" "s/0\.0\.0/${RELEASE_VERSION}/g" "${BUILD_FILE}"
+else
+  sed -i "s/0\.0\.0/${RELEASE_VERSION}/g" "${BUILD_FILE}"
+fi
+
+bazel run --stamp \
+  --define "maven_repo=${CENTRAL_PORTAL_API}" \
+  --define "maven_user=${SONATYPE_USERNAME}" \
+  --define "maven_password=${SONATYPE_PASSWORD}" \
+  //app:maven.publish
+
+echo
+echo "Upload complete. Open https://central.sonatype.com to validate and"
+echo "release the staged deployment, or call the Portal release API."

--- a/tools/publish/publish.sh
+++ b/tools/publish/publish.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Nexus 2 tooling (like bazel_sonatype) continues to work. After upload,
 # the deployment must be released via the Portal UI or Portal API.
 #
-# See: https://central.sonatype.org/pages/ossrh-eol/
+# See: https://central.sonatype.org/pages/ossrh-eol
 
 readonly CENTRAL_PORTAL_API="https://ossrh-staging-api.central.sonatype.com/service/local"
 readonly BUILD_FILE="app/BUILD.bazel"


### PR DESCRIPTION
## Summary

- **Fixes the Maven Central release**, which has been broken since OSSRH (`oss.sonatype.org`) was sunset on 2025-06-30. Publishing is repointed at the Central Portal's OSSRH-compatible staging API (`ossrh-staging-api.central.sonatype.com`), which keeps `bazel_sonatype` 1.1.1 working unchanged.
- **Hardens the release workflow**: replaces the unmaintained `marvinpinto/action-automatic-releases@v1.2.1` with `softprops/action-gh-release@v2`, adds JDK 17 + Bazel cache, and gates `maven-release` / `prefix-version-tag` on a successful `tagged-release` so a broken build can no longer ship.
- **Modernizes CI**: bumps every workflow from JDK 11 to JDK 17 (matching `.bazelrc`), upgrades the deprecated `actions/cache@v3` to `@v4` with per-job keys, removes the dead `inputs.github-token` reference in `unit-tests`, and adds concurrency cancellation on PRs.
- **Consumer action** (`action.yaml`): JDK 17, and floating `vMAJOR` / `vMAJOR.MINOR` tags are now resolved via `gh release list --json tagName` with an anchored regex instead of fragile `grep -Po` against `github.action_path`.
- **Dockerfile**: `ubuntu:24.04` + `alpine:3.20` (3.16 was EOL), bazelisk 1.15.0 → 1.22.1, collapsed apt layers with `--no-install-recommends`, and `chmod 0755` instead of the typo'd `733`.

## Problems this addresses

| # | Area | Problem | Fix |
|---|---|---|---|
| 1 | Release | OSSRH shut down 2025-06-30; `oss.sonatype.org` upload URL returns errors | Use `ossrh-staging-api.central.sonatype.com` (Central Portal OSSRH-compatible API) |
| 2 | Release | `publish.sh` mutates `app/BUILD.bazel` without restoring it | `trap` restores from `.bak` on exit |
| 3 | Release | `marvinpinto/action-automatic-releases@v1.2.1` unmaintained | `softprops/action-gh-release@v2` |
| 4 | Release | No JDK setup, no cache, no test gate | Added `setup-java@v4` (17), `cache@v4`, `needs: tagged-release` |
| 5 | Tests | JDK 11 while `.bazelrc` pins Java 17 | JDK 17 everywhere |
| 6 | Tests | `actions/cache@v3` deprecated (EOL Feb 2025) | `actions/cache@v4` with per-job keys |
| 7 | Tests | `GITHUB_TOKEN: \${{ inputs.github-token }}` is always empty on push/PR | Removed |
| 8 | Action | JDK 11 runtime for the released jar | JDK 17 |
| 9 | Action | Fragile tag regex via `grep -Po` on `github.action_path` | `gh release list --json tagName` + anchored regex |
| 10 | Docker | `alpine:3.16` EOL, bazelisk 1.15.0 years old, `chmod 733`, bloated layers | Ubuntu 24.04 + Alpine 3.20, bazelisk 1.22.1, `chmod 0755`, combined layers |

## Follow-ups (intentionally out of scope)

- `rules_kotlin` 1.9.5 → 2.x and Kotlin language/api level 1.7 → 2.x (consumer-visible toolchain bump)
- Bazel 6.5 → 7/8 LTS and bzlmod (`MODULE.bazel`) migration
- Replace the `./.github` Docker-action indirection in `action.yaml` with a direct `bazel build` step
- Migrate `bazel_sonatype` to a native Central Portal bundle upload once the OSSRH-compat API is eventually retired

## Test plan

- [ ] `Tests` workflow (unit, integration, klint, docker-build-test, buildifier) green on this PR
- [ ] Trigger a push to `main` and verify the `latest` pre-release is produced by `softprops/action-gh-release@v2`
- [ ] Cut a throwaway `vX.Y.Z-rc` tag on a branch and confirm:
  - [ ] `tagged-release` produces `bazel-steward.jar`
  - [ ] `maven-release` uploads to the Central Portal staging area (validate at https://central.sonatype.com)
  - [ ] `prefix-version-tag` force-updates `vX` and `vX.Y` only when the new tag is the latest patch
- [ ] `VirtusLab/bazel-steward@v1` and `@v1.7` from a consumer repo still resolve and download the jar

Made with [Cursor](https://cursor.com)