### PR TITLE
Fix regex for extracting tag names in action.yaml, to take tab delimiter into account

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
         TAG_PATTERN=$(echo "${{ github.action_path }}" | grep -Po "(?<=\/)[^\/]*$")
         if [[ $TAG_PATTERN == v* ]] ;
         then
-          TAG_NAME=$(gh release list -L 100 --repo $REPOSITORY | grep -Eo '^'"$TAG_PATTERN"'[\.0-9]*$' | sort -Vr | head -n 1)
+          TAG_NAME=$(gh release list -L 100 --repo $REPOSITORY | grep -Eo '^'"$TAG_PATTERN"'(\.[0-9]+)*'$'\t' | sort -Vr | head -n 1)
         else
           TAG_NAME=$TAG_PATTERN
         fi


### PR DESCRIPTION
The output of `gh release list` is tab-separated.
```
$ TAG_PATTERN=v1.7.2 && gh release list -L 100 --repo VirtusLab/bazel-steward | head -n5
v1.7.2	Latest	v1.7.2	2026-05-18T12:34:46Z
Development Build	Pre-release	latest	2026-05-06T11:55:07Z
v1.7.2-rc9	Pre-release	v1.7.2-rc9	2026-04-17T09:17:56Z
v1.7.2-rc8	Pre-release	v1.7.2-rc8	2026-04-15T14:26:20Z
v1.7.2-rc7	Pre-release	v1.7.2-rc7	2026-04-15T14:03:00Z
```
Therefore, the regex pattern needs to have `\t` to take the tab delimiter into account.

---

Locally confirmed by

```sh
$ TAG_PATTERN=v1 && gh release list -L 100 --repo VirtusLab/bazel-steward | grep -Eo '^'"$TAG_PATTERN"'(\.[0-9]+)*'$'\t'
v1.7.2	
v1.7.1	
v1.7.0	
v1.6.0	
v1.5.2	
v1.5.1	
v1.5.0	
v1.4.0	
v1.3.0	
v1.2.0	
v1.1.0	
v1.0.2	
v1.0.1
$ TAG_PATTERN=v1.7.2 && gh release list -L 100 --repo VirtusLab/bazel-steward | grep -Eo '^'"$TAG_PATTERN"'(\.[0-9]+)*'$'\t'
v1.7.2
$ TAG_PATTERN=v1.7.3 && gh release list -L 100 --repo VirtusLab/bazel-steward | grep -Eo '^'"$TAG_PATTERN"'(\.[0-9]+)*'$'\t' | wc -l
0
$ TAG_PATTERN=v1.7 && gh release list -L 100 --repo VirtusLab/bazel-steward | grep -Eo '^'"$TAG_PATTERN"'(\.[0-9]+)*'$'\t'
v1.7.2	
v1.7.1	
v1.7.0
```
