### PR TITLE
Stop publishing resolve-release-tag.jar on GitHub releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - run: bazel build //app:app_deploy.jar //action:resolve_release_tag_cli_deploy.jar
-        name: Build project jars
+      - run: bazel build //app:app_deploy.jar
+        name: Build steward jar
       - name: Verify action release-tag matches git tag
         if: github.ref_type == 'tag'
         run: |
@@ -31,8 +31,6 @@ jobs:
           fi
       - run: mv bazel-bin/app/app_deploy.jar bazel-steward.jar
         name: Rename steward jar
-      - run: cp bazel-bin/action/resolve_release_tag_cli_deploy.jar action/resolve-release-tag.jar
-        name: Copy resolve-release-tag jar into action tree
       - uses: marvinpinto/action-automatic-releases@v1.2.1
         name: Publish
         with:
@@ -42,7 +40,6 @@ jobs:
           automatic_release_tag: ${{ github.ref_type != 'tag' && 'latest' || null }}
           files: |
             bazel-steward.jar
-            action/resolve-release-tag.jar
   maven-release:
     runs-on: "ubuntu-latest"
     if: github.ref_type == 'tag'


### PR DESCRIPTION
The jar stays in the action tree for SHA pins; releases should only ship bazel-steward.jar.