### PR TITLE
Improve tests.yml CI runtime

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,6 @@ build --tool_java_language_version=17
 build --tool_java_runtime_version=remotejdk_17
 
 test --test_output=errors
+
+# CI profile: enables a disk cache for compiled outputs across runs.
+build:ci --disk_cache=/tmp/bazel-disk-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,24 @@ jobs:
         run: |
           echo "::warning title=Deprecated check::The 'klint-tests' job is a no-op stub. Kotlin formatting now runs inside the 'pre-commit' job. Update branch protection to require 'pre-commit' instead, then remove this stub."
 
+  # Deprecated: kept only to satisfy branch protection. Replaced by
+  # test-smoke-steward-on-its-repo.
+  docker-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deprecation notice
+        run: |
+          echo "::warning title=Deprecated check::The 'docker-build-test' job is a no-op stub. Update branch protection to require 'test-smoke-steward-on-its-repo' instead, then remove this stub."
+
+  # Deprecated: kept only to satisfy branch protection. Replaced by the
+  # integration-core-tests and integration-rules-tests matrix entries.
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deprecation notice
+        run: |
+          echo "::warning title=Deprecated check::The 'integration-tests' job is a no-op stub. Update branch protection to require 'integration-core-tests' and 'integration-rules-tests' instead, then remove this stub."
+
   # Runs steward against the bazel-steward repo itself (real MODULE.bazel,
   # maven_install.json, full git history) to catch regressions on real-world input.
   test-smoke-steward-on-its-repo:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - name: integration-core
             tag: integration
             # All integration tests except the large rules suite, which runs separately.
-            target: "//... -- -//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
+            target: "//... -//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
           - name: integration-rules
             tag: integration
             target: "//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
@@ -49,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bazel-disk-${{ matrix.name }}-
       - name: Run tests
-        run: bazel test ${{ matrix.target }} --keep_going --test_tag_filters=${{ matrix.tag }} --config=ci
+        run: bazel test --keep_going --test_tag_filters=${{ matrix.tag }} --config=ci -- ${{ matrix.target }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/bazel-disk-cache
-          key: ${{ runner.os }}-bazel-disk-${{ matrix.name }}-${{ github.sha }}
+          key: ${{ runner.os }}-bazel-disk-${{ matrix.name }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'maven_install.json') }}
           restore-keys: |
             ${{ runner.os }}-bazel-disk-${{ matrix.name }}-
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,14 @@ jobs:
         include:
           - name: unit
             tag: unit
-          - name: integration
+            target: "//..."
+          - name: integration-core
             tag: integration
+            # All integration tests except the large rules suite, which runs separately.
+            target: "//... -//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
+          - name: integration-rules
+            tag: integration
+            target: "//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
     name: ${{ matrix.name }}-tests
     steps:
       - uses: actions/checkout@v4
@@ -28,16 +34,22 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Cache Bazel
+      - name: Cache Bazel repository cache
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazel
+          path: ~/.cache/bazel
           key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'maven_install.json') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
+      - name: Cache Bazel disk cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/bazel-disk-cache
+          key: ${{ runner.os }}-bazel-disk-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-disk-${{ matrix.name }}-
       - name: Run tests
-        run: bazel test //... --keep_going --test_tag_filters=${{ matrix.tag }}
+        run: bazel test ${{ matrix.target }} --keep_going --test_tag_filters=${{ matrix.tag }} --config=ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,7 +64,7 @@ jobs:
           java-version: 17
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.12'
       - name: Cache pre-commit (incl. ktlint jar)
         uses: actions/cache@v4
         with:
@@ -82,19 +94,28 @@ jobs:
         run: |
           echo "::warning title=Deprecated check::The 'klint-tests' job is a no-op stub. Kotlin formatting now runs inside the 'pre-commit' job. Update branch protection to require 'pre-commit' instead, then remove this stub."
 
-  docker-build-test:
+  # Runs steward against the bazel-steward repo itself (real MODULE.bazel,
+  # maven_install.json, full git history) to catch regressions on real-world input.
+  test-smoke-steward-on-its-repo:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Integration tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Run steward on this repo
         uses: ./
         with:
           use-release: "false"
           push-to-remote: "false"
+        env:
+          DOCKER_CACHE_FROM: type=gha,scope=docker-steward
+          DOCKER_CACHE_TO: type=gha,mode=max,scope=docker-steward
 
-  action-smoke-test:
+  # Runs steward from a separate action-src checkout against a minimal consumer
+  # fixture, verifying the cross-repo consumption pattern (issue #459).
+  test-smoke-steward-on-external-repo:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -103,6 +124,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: action-src
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Materialize consumer repo at workspace root
         run: ./action-src/tools/smoke/setup-consumer.sh
       - name: Run bazel-steward from consumer (use-release false)
@@ -112,3 +135,5 @@ jobs:
           push-to-remote: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_CACHE_FROM: type=gha,scope=docker-steward
+          DOCKER_CACHE_TO: type=gha,mode=max,scope=docker-steward

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - name: integration-core
             tag: integration
             # All integration tests except the large rules suite, which runs separately.
-            target: "//... -//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
+            target: "//... -- -//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"
           - name: integration-rules
             tag: integration
             target: "//e2e/src/test/kotlin/org/virtuslab/bazelsteward/e2e/rules:all"

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,13 @@ runs:
         set -euo pipefail
         CONTEXT="${GITHUB_ACTION_PATH}"
         IMAGE="bazel-steward-build-$$"
-        docker build -f "${CONTEXT}/Dockerfile" -t "${IMAGE}" "${CONTEXT}"
+        docker buildx build \
+          ${DOCKER_CACHE_FROM:+--cache-from "${DOCKER_CACHE_FROM}"} \
+          ${DOCKER_CACHE_TO:+--cache-to "${DOCKER_CACHE_TO}"} \
+          --load \
+          -t "${IMAGE}" \
+          -f "${CONTEXT}/Dockerfile" \
+          "${CONTEXT}"
         CID=$(docker create "${IMAGE}")
         docker cp "${CID}:/opt/bazel-steward.jar" ./bazel-steward.jar
         docker rm "${CID}"


### PR DESCRIPTION
- Shard integration tests: split the large rules suite into its own matrix entry (integration-rules) so it runs in parallel with integration-core
- Add Bazel disk cache (--config=ci) to persist compiled outputs across runs
- Rename docker jobs to test-smoke-steward-on-{its,external}-repo to better describe what each verifies
- Switch Docker build to buildx with optional GHA layer cache via DOCKER_CACHE_FROM/DOCKER_CACHE_TO env vars; set these in both smoke jobs so the second build gets a warm cache hit
- Downgrade pre-commit Python from 3.14 (pre-release) to 3.12 (LTS)