### PR TITLE
fix: update all classifier variants of an artifact in one pass

### DIFF
--- a/app/src/test/kotlin/org/virtuslab/bazelsteward/app/VersionReplacementHeuristicTest.kt
+++ b/app/src/test/kotlin/org/virtuslab/bazelsteward/app/VersionReplacementHeuristicTest.kt
@@ -8,6 +8,8 @@ import org.virtuslab.bazelsteward.core.common.FileChange
 import org.virtuslab.bazelsteward.core.common.TextFile
 import org.virtuslab.bazelsteward.core.common.UpdateSuggestion
 import org.virtuslab.bazelsteward.core.library.SemanticVersion
+import org.virtuslab.bazelsteward.core.library.SimpleVersion
+import org.virtuslab.bazelsteward.core.library.Version
 import org.virtuslab.bazelsteward.core.replacement.LibraryUpdateResolver
 import org.virtuslab.bazelsteward.core.replacement.PythonFunctionCallHeuristic
 import org.virtuslab.bazelsteward.core.replacement.VersionOnlyInStringLiteralHeuristic
@@ -40,6 +42,27 @@ class VersionReplacementHeuristicTest {
     val updated = content.replaceRange(change.offset, change.offset + change.length, change.replacement)
     updated.lines()[2] shouldBe """        "io.get-coursier:interface:1.0.28","""
     updated.lines()[2].count { it == '"' } shouldBe 2
+  }
+
+  @Test
+  fun `should update every classifier variant of the same artifact in one pass`() {
+    val content = listOf(
+      """    "tools.profiler:async-profiler:4.4",""",
+      """    "tools.profiler:async-profiler:4.4:linux-arm64",""",
+      """    "tools.profiler:async-profiler:4.4:linux-x64",""",
+      """    "tools.profiler:async-profiler:4.4:macos",""",
+    ).joinToString("\n")
+    // rules_jvm_external strips classifiers, so all four artifacts collapse into
+    // a single update for tools.profiler:async-profiler 4.4 -> 4.5.
+    val library = MavenCoordinates.of("tools.profiler", "async-profiler", "4.4")
+    val changes = resolveAllUpdatesIn(content, library, SimpleVersion("4.5"), WholeLibraryHeuristic)
+
+    changes.map { it.replacement }.distinct() shouldBe listOf("4.5")
+    changes.size shouldBe 4
+
+    val updated = content.applyChanges(changes)
+    updated.lines().count { it.contains("async-profiler:4.5") } shouldBe 4
+    updated.lines().count { it.contains("async-profiler:4.4") } shouldBe 0
   }
 
   @Nested
@@ -275,4 +298,23 @@ class VersionReplacementHeuristicTest {
     }
     return resolver.resolve(listOf(file), UpdateSuggestion(library, suggested), heuristics.toList())?.fileChanges?.firstOrNull()
   }
+
+  private fun resolveAllUpdatesIn(
+    content: String,
+    library: MavenCoordinates,
+    suggested: Version,
+    vararg heuristics: VersionReplacementHeuristic = allHeuristics,
+  ): List<FileChange> {
+    val file = object : TextFile {
+      override val path = Path("MODULE.bazel")
+      override val content = content
+    }
+    return resolver.resolve(listOf(file), UpdateSuggestion(library, suggested), heuristics.toList())?.fileChanges.orEmpty()
+  }
+
+  private fun String.applyChanges(changes: List<FileChange>): String =
+    changes.sortedByDescending { it.offset }
+      .fold(this) { acc, change ->
+        acc.replaceRange(change.offset, change.offset + change.length, change.replacement)
+      }
 }

--- a/core/src/main/kotlin/org/virtuslab/bazelsteward/core/replacement/WholeLibraryHeuristic.kt
+++ b/core/src/main/kotlin/org/virtuslab/bazelsteward/core/replacement/WholeLibraryHeuristic.kt
@@ -13,26 +13,36 @@ object WholeLibraryHeuristic : VersionReplacementHeuristic {
     val regexes = markers.map { marker ->
       (marker + currentVersion).map { """(${Regex.escape(it)})""" }.reduce { acc, s -> "$acc.*$s" }.toRegex()
     }
-    val matchResult = regexes.firstNotNullOfOrNull { regex ->
+    val matches = regexes.firstNotNullOfOrNull { regex ->
       files.firstNotNullOfOrNull { textFile ->
         regex.findAll(textFile.content)
           .map { MatchedText(it, textFile.path) }
-          .sortedBy { it.matchedText.length }
-          .firstOrNull()
+          .toList()
+          .takeIf { it.isNotEmpty() }
       }
     } ?: return null
-    val versionOffset = matchResult.offsetLastMatchGroup ?: return null
 
-    return LibraryUpdate(
-      updateSuggestion,
-      listOf(
-        FileChange(
-          matchResult.origin,
-          versionOffset,
-          updateSuggestion.currentLibrary.version.value.length,
-          updateSuggestion.suggestedVersion.value,
-        ),
-      ),
-    )
+    // Artifacts that differ only by a classifier (e.g. "g:a:1.0" and
+    // "g:a:1.0:linux-x64") are reported identically by rules_jvm_external, so
+    // they collapse into a single update yet occur on several lines. Update
+    // every occurrence whose match is as tight as the tightest one. Looser
+    // matches are spurious spillover from a prefix collision (e.g. the marker
+    // for "junit-jupiter" also matching inside "junit-jupiter-engine").
+    val minLength = matches.minOf { it.matchedText.length }
+    val fileChanges = matches
+      .filter { it.matchedText.length == minLength }
+      .mapNotNull { match ->
+        match.offsetLastMatchGroup?.let { versionOffset ->
+          FileChange(
+            match.origin,
+            versionOffset,
+            updateSuggestion.currentLibrary.version.value.length,
+            updateSuggestion.suggestedVersion.value,
+          )
+        }
+      }
+      .ifEmpty { return null }
+
+    return LibraryUpdate(updateSuggestion, fileChanges)
   }
 }


### PR DESCRIPTION
Maven artifacts that differ only by a classifier (e.g.
"tools.profiler:async-profiler:4.5" and its ":linux-x64", ":macos",
":linux-arm64" variants) are reported identically by rules_jvm_external,
which strips the classifier. They therefore collapse into a single
UpdateSuggestion -- which is correct, since the variants are one release
and must move in lockstep -- but occur on several lines in MODULE.bazel.

WholeLibraryHeuristic emitted a FileChange only for the first, shortest
match, so a single run rewrote one line and the remaining variants were
left behind. Over successive runs bazel-steward opened one PR per line
instead of bumping them together.

Emit a FileChange for every occurrence whose match is as tight as the
tightest one. That covers all classifier variant lines while still
excluding looser prefix-collision matches (e.g. the "junit-jupiter"
marker also matching inside "junit-jupiter-engine"), which the existing
shortest-match preference guarded against.
